### PR TITLE
refactored addon class/template for rootURL

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -9,5 +9,5 @@
   width="{{this.size}}" 
   xmlns="http://www.w3.org/2000/svg"
 >
-  <use href='./ember-flight-icons/icons/sprite.svg#{{@name}}-{{this.size}}'></use>
+  <use href='{{this.contextRootURL}}ember-flight-icons/icons/sprite.svg#{{@name}}-{{this.size}}'></use>
 </svg>

--- a/ember-flight-icons/addon/components/flight-icon.js
+++ b/ember-flight-icons/addon/components/flight-icon.js
@@ -1,7 +1,13 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import { getOwner } from '@ember/application';
 
 export default class FlightIconComponent extends Component {
+  get contextRootURL() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return config.rootURL || '/';
+  }
+
   /**
    * Sets the fillColor for the SVG
    *


### PR DESCRIPTION
## Summary
If merged, this PR refactors the component class and template to get the rootURL from the app so nested apps consume the addon correctly. 

Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR. 

## Tests
All tests pass. 