### PR TITLE
update flight-export actions to open PRs

### DIFF
--- a/.github/workflows/export-go.compile.yml
+++ b/.github/workflows/export-go.compile.yml
@@ -16,8 +16,9 @@ jobs:
         working-directory: ./export-go
         run: go build -ldflags "-X 'main.flightVersion=$(date -u '+%Y%m%d.%H%M%S')'"
 
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v7
+      - name: Open a PR
+        uses: peter-evans/create-pull-request@v3
         with:
-          message: 'Auto-commit of new binary'
-          add: './export-go/flight'
+          commit-message: 'new flight-export binary'
+          title: 'New flight-export binary'
+          body: ''

--- a/.github/workflows/export-go.main.yml
+++ b/.github/workflows/export-go.main.yml
@@ -16,8 +16,9 @@ jobs:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
         run: ./flight
 
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v7
+      - name: Open a PR
+        uses: peter-evans/create-pull-request@v3
         with:
-          message: 'Auto-commit of icon updates'
-          add: '*'
+          commit-message: 'updated export of flight icons'
+          title: 'Updated export of icons from Figma'
+          body: ''


### PR DESCRIPTION
this should allow us to re-enable branch protection on main. we'll have to test this in prod though to confirm...

![source](https://user-images.githubusercontent.com/1672302/129227663-49431924-eef3-4f26-9df7-32a2e167381d.gif)
