### PR TITLE
Revert "update package name to @hashicorp/ember-flight-icons"

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hashicorp/ember-flight-icons",
+  "name": "ember-flight-icons",
   "version": "0.0.0",
   "description": "The Ember addon for the HashiCorp icon set",
   "keywords": [


### PR DESCRIPTION
Reverts hashicorp/flight#46

This change actually breaks the addon because references to the package need to also be updated. Let's revert to get things working and revisit this and ensure tests are passing before merging.