### PR TITLE
rename package to @hashicorp/ember-flight-icons

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -9,5 +9,5 @@
   width="{{this.size}}" 
   xmlns="http://www.w3.org/2000/svg"
 >
-  <use href='{{this.contextRootURL}}ember-flight-icons/icons/sprite.svg#{{@name}}-{{this.size}}'></use>
+  <use href='{{this.contextRootURL}}@hashicorp/ember-flight-icons/icons/sprite.svg#{{@name}}-{{this.size}}'></use>
 </svg>

--- a/ember-flight-icons/app/components/flight-icon.js
+++ b/ember-flight-icons/app/components/flight-icon.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-flight-icons/components/flight-icon';
+export { default } from '@hashicorp/ember-flight-icons/components/flight-icon';

--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-flight-icons",
+  "name": "@hashicorp/ember-flight-icons",
   "version": "0.0.0",
   "description": "The Ember addon for the HashiCorp icon set",
   "keywords": [


### PR DESCRIPTION
Attempt 2 at https://github.com/hashicorp/flight/pull/46 except more (all 🤞 ) places are now updated to reflect the change

![source](https://user-images.githubusercontent.com/1672302/129609766-7cc5bd21-c62e-42fc-9ff0-25c72369e144.gif)


✅  tests pass locally
