### PR TITLE
added node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .DS_Store
+node_modules/


### PR DESCRIPTION
If merged, this PR adds the `node_modules` folder to the `.gitignore` file at the root of the repository. 