### PR TITLE
Changes default icon size to 16x16

### DIFF
--- a/ember-flight-icons/README.md
+++ b/ember-flight-icons/README.md
@@ -29,7 +29,7 @@ ember install @hashicorp/ember-flight-icons
 
 ### Required usage
 
-The `name` must be specified. A default icon size of 24 will be provided.
+The `name` must be specified. A default icon size of 16 is provided.
 
 ```hbs
 <FlightIcon @name="activity" />

--- a/ember-flight-icons/README.md
+++ b/ember-flight-icons/README.md
@@ -43,7 +43,7 @@ Icons are set to a `viewBox` square size of 16 by default.
 <FlightIcon @name="activity" />
 ```
 
-Currently, we support a `viewBox` square size of 24 or 16. If you need your icon to be larger than 16, pass in `size`.
+Currently, we support a `viewBox` square size of 16 or 24. If you need your icon to be larger than 16, pass in `size`.
 
 ```hbs
 <FlightIcon @name="activity" @size="24" />

--- a/ember-flight-icons/README.md
+++ b/ember-flight-icons/README.md
@@ -37,16 +37,16 @@ The `name` must be specified. A default icon size of 24 will be provided.
 
 ### Optional usage
 
-Icons are set to a `viewBox` square size of 24 by default.
+Icons are set to a `viewBox` square size of 16 by default.
 
 ```hbs
 <FlightIcon @name="activity" />
 ```
 
-Currently, we support a `viewBox` square size of 24 or 16. If you need your icon to be smaller than 24, pass in `size`.
+Currently, we support a `viewBox` square size of 24 or 16. If you need your icon to be larger than 16, pass in `size`.
 
 ```hbs
-<FlightIcon @name="activity" @size="16" />
+<FlightIcon @name="activity" @size="24" />
 ```
 
 Icons are set to `display: inline-block` by default. To remove this, set `isInlineBlock` to `false`:

--- a/ember-flight-icons/addon/components/flight-icon.js
+++ b/ember-flight-icons/addon/components/flight-icon.js
@@ -55,13 +55,13 @@ export default class FlightIconComponent extends Component {
   }
 
   /**
-   * Gets the icon's size (small or large)
+   * Gets the icon's size (16 or 24)
    *
    * @param size
    * @returns the value of `size` if set
-   * @default `24`
+   * @default `16`
    */
   get size() {
-    return this.args.size ?? '24';
+    return this.args.size ?? '16';
   }
 }

--- a/ember-flight-icons/tests/dummy/app/templates/application.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/application.hbs
@@ -37,7 +37,7 @@
         <li class="ds-li {{if meta.isHidden 'd-none'}}">
           <FlightIcon
             @name={{Onlyname meta.name}}
-            @size={{if (eq meta.size 16) '16'}}
+            @size={{if (eq meta.size 24) '24'}}
             class="demo-icon"
           />
           {{meta.name}}

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -25,20 +25,20 @@ module('Integration | Component | flight-icon', function (hooks) {
       .dom('svg.flight-icon.icon-activity.display-inline')
       .hasAttribute('aria-hidden');
   });
-  // the component should render the 24x24 icon by default
-  test('it renders the 24x24 icon by default', async function (assert) {
+  // the component should render the 16x16 icon by default
+  test('it renders the 16x16 icon by default', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
-    assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
-      height: '24px',
-      width: '24px',
-    });
-  });
-  // the component should render the 16x16 icon if size is set
-  test('it renders the 16x16 icon when option is set', async function (assert) {
-    await render(hbs`<FlightIcon @name="activity" @size="16" />`);
     assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
       height: '16px',
       width: '16px',
+    });
+  });
+  // the component should render the 24x24 icon if size is set
+  test('it renders the 24x24 icon when option is set', async function (assert) {
+    await render(hbs`<FlightIcon @name="activity" @size="24" />`);
+    assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
+      height: '24px',
+      width: '24px',
     });
   });
   // the component should not have a class of `display-inline` if that option has been set


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR resolves #78 

Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

## :hammer_and_wrench: Detailed Description

This PR changes the default size of the icon from 24x24 to 16x16. The tests and documentation were also updated to reflect the changes made in the component.

Note: Two test scenarios, `ember-canary` and `embroider-optimized` are not currently passing. We have confirmed that the `ember-canary` scenario is widespread and not due to this addon. We are looking into the `embroider-optimized` scenario but as we are not currently using embroider or optimizing for it, it is not a blocker if this scenario does not pass right now. 

## :+1: Definition of Done

- [x] New/updated functionality works 
- [x] Tests added/updated
- [x] Docs updated
