### PR TITLE
allow canary and embroiderOptimized scenarios to fail

### DIFF
--- a/ember-flight-icons/config/ember-try.js
+++ b/ember-flight-icons/config/ember-try.js
@@ -41,6 +41,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
@@ -76,7 +77,7 @@ module.exports = async function () {
         },
       },
       embroiderSafe(),
-      embroiderOptimized(),
+      embroiderOptimized({ allowedToFail: true }),
     ],
   };
 };


### PR DESCRIPTION
## :pushpin: Summary

Addresses https://github.com/hashicorp/flight/pull/95 by allowing the flaky tests to fail without failing the overall build

<img width="461" alt="Screen Shot 2021-08-23 at 15 47 44" src="https://user-images.githubusercontent.com/1672302/130517316-a2ee8b00-d3f4-420e-b331-08c6e38974af.png">


## :+1: Definition of Done
- [x] The scenarios in question fail in their runs but don't fail the overall action
- [x] We are happy with this approach vs just deleting the tests entirely
