### PR TITLE
Add npm badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ Please see [ember-flight-icons/README](ember-flight-icons/README.md).
 
 ## How to consume just the SVGs in your Ember or React app
 
-Use [npmjs.com/package/@hashicorp/flight-icons](https://www.npmjs.com/package/@hashicorp/flight-icons), which is currently in beta.
+[![npm version](https://badge.fury.io/js/%40hashicorp%2Fflight-icons.svg)](https://badge.fury.io/js/%40hashicorp%2Fflight-icons)
+
+🚨 Note: npm addon is currently in beta and not intended for production use yet. 


### PR DESCRIPTION
## :pushpin: Summary

I am using this PR as a way to show our Vercel setup working. Figured would add the npm badge as a mergeable example.

Once this merged, or anything else is merged to `main`, we should be able to see https://flight-rho.vercel.app/ working.

## :link: External Links

Vercel setup: https://vercel.com/hashicorp/flight/settings/domains
Resolves: https://github.com/hashicorp/flight/issues/53