### PR TITLE
bug: resolved issue where currentColor was not being set properly

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -3,7 +3,7 @@
   ...attributes
   aria-hidden="true"
   data-test-icon
-  fill={{@color}} 
+  fill="{{this.color}}"
   height="{{this.size}}"
   id={{this.iconId}}
   viewBox="0 0 {{this.size}} {{this.size}}"

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -60,6 +60,21 @@ module('Integration | Component | flight-icon', function (hooks) {
       fill: 'rgb(186, 34, 38)',
     });
   });
-  // TODO: the component should have `color` set to `currentColor` by default
+  // the component should have `color` set to `currentColor` (black) by default
+  test('the fill should be set to black by default', async function (assert) {
+    await render(hbs`<FlightIcon @name="meh" />`);
+    assert.dom(`svg.flight-icon`).hasStyle({
+      fill: 'rgb(0, 0, 0)',
+    });
+  });
+  // currentColor should change per inheritance rules
+  test('The fill color should be able to be inherited from parent', async function (assert) {
+    await render(
+      hbs`<div style="color:blue;"><FlightIcon @name="meh" /></div>`
+    );
+    assert.dom(`svg.flight-icon`).hasStyle({
+      fill: 'rgb(0, 0, 255)',
+    });
+  });
   // TODO: there should be an error if an icon name is not provided
 });


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR resolves the issue where currentColor was not being inherited correctly.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

## :hammer_and_wrench: Detailed Description
- updated component template to pass `currentColor` correctly
- added tests to check that the default works as expected, and that currentColor is inherited correctly.
