### PR TITLE
Fix CODEOWNERS functionality

### DIFF
--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,1 +1,3 @@
-@hashicorp/design-systems
+# These owners will be requested for
+# review when someone opens a pull request.
+*       @hashicorp/design-systems


### PR DESCRIPTION
## :pushpin: Summary

I missed the `*` before.

Fix to: https://github.com/hashicorp/flight/pull/104
Ref: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners