### PR TITLE
[🚧 WIP] Update usage instructions for -16 vs -24 icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please see [ember-flight-icons/README](ember-flight-icons/README.md).
 
 🚨 Note: npm addon is currently in beta and not intended for production use yet.
 
-This addon can be used in React or Ember apps.
+Please see [flight-icons/README](flight-icons/README.md).
 
 ## Development instructions for `@hashicorp/ember-flight-icons` and `@hashicorp/flight-icons`
 

--- a/flight-icons/README.md
+++ b/flight-icons/README.md
@@ -10,15 +10,17 @@ yarn add @hashicorp/flight-icons
 
 ## Usage
 
-### How to choose 16 or 24 viewBox size
+We intend for icons to be used at a 16 or 24 `viewBox` size.
 
-* If an icon is in a viewBox <= 16, use the `-16` version of the icon.
-* If an icon is in a 16 < viewBox < 24, use your discretion. <!-- TBH I'm not sure, just put in a placeholder. -->
-* If an icon is in a viewBox >= 24, use the `-24` version of the icon.
+### How to choose 16 or 24 `viewBox` size
+
+* If an icon is in a `viewBox` <= 16, use the `-16` version of the icon.
+* If an icon is in a 16 < `viewBox` < 24, default to the `-16` version of the icon. If you're not sure, please ping the Design Systems team: [@hashicorp/design-systems on GitHub](https://github.com/orgs/hashicorp/teams/design-systems) or [#team-design-systems on Slack](https://app.slack.com/client/T024UT03C/C7KTUHNUS/thread/C7KTUHNUS-1630354922.058700).
+* If an icon is in a `viewBox` >= 24, use the `-24` version of the icon.
 
 ### Guidelines for other sizes
 
-* If you're scaling an icon with a parent component or styling, do not stretch a `-16` icon to a `24` viewBox.
+* If you're scaling an icon with a parent component or styling, do **not** stretch a `-16` icon to a `24` viewBox.
 
 ## Contributing
 

--- a/flight-icons/README.md
+++ b/flight-icons/README.md
@@ -1,6 +1,6 @@
 # flight-icons
 
-An addon for the icons from `flight`. Currently in development.
+An addon for the icons from `flight`. Currently in development. This addon can be used in React or Ember apps.
 
 ## Installation
 

--- a/flight-icons/README.md
+++ b/flight-icons/README.md
@@ -1,0 +1,33 @@
+# flight-icons
+
+An addon for the icons from `flight`. Currently in development.
+
+## Installation
+
+```bash
+yarn add @hashicorp/flight-icons
+```
+
+## Usage
+
+### How to choose 16 or 24 viewBox size
+
+* If an icon is in a viewBox <= 16, use the `-16` version of the icon.
+* If an icon is in a 16 < viewBox < 24, use your discretion. <!-- TBH I'm not sure, just put in a placeholder. -->
+* If an icon is in a viewBox >= 24, use the `-24` version of the icon.
+
+### Guidelines for other sizes
+
+* If you're scaling an icon with a parent component or styling, do not stretch a `-16` icon to a `24` viewBox.
+
+## Contributing
+
+🚧 TBD
+
+## License
+
+This project is licensed under the [Mozilla Public License 2.0](LICENSE.md).
+
+## Versioning
+
+We use [SemVer](http://semver.org/) for versioning.


### PR DESCRIPTION
## :pushpin: Summary

First stab at instructions based on https://github.com/hashicorp/boundary-ui/pull/720 discussion on PR, Slack, and in person. Looking for feedback!

Review commit-by-commit

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.

## 👉 Next steps

- [table for now] TODO: File ticket if seems like a good incremental next step? Ideally we could embed flight-icons/README and ember-flight-icons/README to display on https://flight-staging.vercel.app/. We can also update all 3 in tandem, in case we want to display stuff differently on https://flight-staging.vercel.app/ ... if as a team we are cool with that?