### PR TITLE
[WIP] Improvements including documentation additions

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -2,7 +2,7 @@
   class="flight-icon icon-{{@name}} {{if this.display "display-inline"}}"
   ...attributes
   aria-hidden="true"
-  data-test-icon
+  data-test-icon="{{this.iconId}}"
   fill="{{this.color}}"
   height="1em"
   id={{this.iconId}}

--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -4,10 +4,10 @@
   aria-hidden="true"
   data-test-icon
   fill="{{this.color}}"
-  height="{{this.size}}"
+  height="1em"
   id={{this.iconId}}
   viewBox="0 0 {{this.size}} {{this.size}}"
-  width="{{this.size}}" 
+  width="1em" 
   xmlns="http://www.w3.org/2000/svg"
 >
   <use href='{{this.contextRootURL}}@hashicorp/ember-flight-icons/icons/sprite.svg#{{@name}}-{{this.size}}'></use>

--- a/ember-flight-icons/tests/dummy/app/router.js
+++ b/ember-flight-icons/tests/dummy/app/router.js
@@ -6,4 +6,7 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function () {});
+Router.map(function () {
+  this.route('design');
+  this.route('engineering');
+});

--- a/ember-flight-icons/tests/dummy/app/routes/design.js
+++ b/ember-flight-icons/tests/dummy/app/routes/design.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class DesignRoute extends Route {}

--- a/ember-flight-icons/tests/dummy/app/routes/engineering.js
+++ b/ember-flight-icons/tests/dummy/app/routes/engineering.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class EngineeringRoute extends Route {}

--- a/ember-flight-icons/tests/dummy/app/styles/app.css
+++ b/ember-flight-icons/tests/dummy/app/styles/app.css
@@ -84,7 +84,7 @@ ul.ds-ul-grid li.ds-li {
   align-items: center;
   display: flex;
   flex-direction: column;
-  font-size: 0.75em;
+  font-size: 1.2em;
   gap: 1ch;
   justify-content: center;
   padding: 0.5em 0.15em 0.15em;
@@ -108,13 +108,14 @@ ul.ds-ul-grid li.ds-li:hover .ds-icon-frame {
   color: var(--brand-link);
   box-shadow: 0 0 0 1px var(--info-l1);
 }
-ul.ds-ul-grid li.ds-li p {
-  text-align: center;
+ul.ds-ul-grid li.ds-li p.ds-p {
+  font-size: 0.75em;
   margin-top: auto;
-  width: 100%;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
   white-space: nowrap;
+  width: 100%;
 }
 
 footer.ds-footer {

--- a/ember-flight-icons/tests/dummy/app/templates/application.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/application.hbs
@@ -40,7 +40,7 @@
               class="demo-icon"
             />
           </div>
-          <p>{{meta.name}}</p>
+          <p class="ds-p">{{meta.name}}</p>
         </li>
       {{/each}}
     </ul>

--- a/ember-flight-icons/tests/dummy/app/templates/design.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/design.hbs
@@ -1,0 +1,2 @@
+{{page-title "Design"}}
+{{outlet}}

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -1,0 +1,2 @@
+{{page-title "Engineering"}}
+{{outlet}}

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -6,26 +6,22 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | flight-icon', function (hooks) {
   setupRenderingTest(hooks);
 
-  // the component should render
   test('it renders the icon', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert
       .dom('svg.flight-icon.icon-activity.display-inline')
       .matchesSelector('svg');
   });
-  // the component should have a matching class name
   test('it should have a class name that is the same as the component name', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert.dom('svg').hasClass('flight-icon');
   });
-  // the component should have aria-hidden as true
   test('it has aria-hidden set to true', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert
       .dom('svg.flight-icon.icon-activity.display-inline')
       .hasAttribute('aria-hidden');
   });
-  // the component should render the 16x16 icon by default
   test('it renders the 16x16 icon by default', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
@@ -33,7 +29,6 @@ module('Integration | Component | flight-icon', function (hooks) {
       width: '16px',
     });
   });
-  // the component should render the 24x24 icon if size is set
   test('it renders the 24x24 icon when option is set', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @size="24" />`);
     assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
@@ -41,17 +36,14 @@ module('Integration | Component | flight-icon', function (hooks) {
       width: '24px',
     });
   });
-  // the component should not have a class of `display-inline` if that option has been set
   test('it does not have the display-inline class if the option is set to false', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @isInlineBlock={{false}} />`);
     assert.dom('svg.flight-icon').doesNotHaveClass('display-inline');
   });
-  // the component should support appending additional CSS classes when invoked
   test('additional classes can be added when component is invoked', async function (assert) {
     await render(hbs`<FlightIcon @name="meh" class="demo" />`);
     assert.dom(`svg.flight-icon`).hasClass('demo');
   });
-  // The component color property should accept :root variable values
   test('the color property should accept :root variable values', async function (assert) {
     await render(
       hbs`<FlightIcon @name="alert-circle" @color="var(--danger-d1)" />`
@@ -60,14 +52,12 @@ module('Integration | Component | flight-icon', function (hooks) {
       fill: 'rgb(186, 34, 38)',
     });
   });
-  // the component should have `color` set to `currentColor` (black) by default
   test('the fill should be set to black by default', async function (assert) {
     await render(hbs`<FlightIcon @name="meh" />`);
     assert.dom(`svg.flight-icon`).hasStyle({
       fill: 'rgb(0, 0, 0)',
     });
   });
-  // currentColor should change per inheritance rules
   test('The fill color should be able to be inherited from parent', async function (assert) {
     await render(
       hbs`<div style="color:blue;"><FlightIcon @name="meh" /></div>`

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -24,17 +24,15 @@ module('Integration | Component | flight-icon', function (hooks) {
   });
   test('it renders the 16x16 icon by default', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
-    assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
-      height: '16px',
-      width: '16px',
-    });
+    assert
+      .dom('svg.flight-icon.icon-activity.display-inline')
+      .hasAttribute('viewBox', '0 0 16 16');
   });
   test('it renders the 24x24 icon when option is set', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @size="24" />`);
-    assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
-      height: '24px',
-      width: '24px',
-    });
+    assert
+      .dom('svg.flight-icon.icon-activity.display-inline')
+      .hasAttribute('viewBox', '0 0 24 24');
   });
   test('it does not have the display-inline class if the option is set to false', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @isInlineBlock={{false}} />`);


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR resolves some issues: 

- sets the height and width to 1em so that they are always proportional within the context they are being used (see [this CodePen](https://codepen.io/melsumner/pen/1143304b4933a757d0a1e8233881bba7?editors=1100) for examples of contextual use)
- updates the demo app to accommodate for the proportional icon sizes
- sets the data-test-icon value to the ID (before there was no value)
- adds routes for /design and /engineering to dummy app so we can add more documentation


Notes: 
- I've tried to separate all work into distinct commits so if we want to cherry pick/revert it's possible (progress!) 

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.

