### PR TITLE
fix: changes height and width to relational units

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -4,10 +4,10 @@
   aria-hidden="true"
   data-test-icon
   fill="{{this.color}}"
-  height="{{this.size}}"
+  height="1em"
   id={{this.iconId}}
   viewBox="0 0 {{this.size}} {{this.size}}"
-  width="{{this.size}}" 
+  width="1em" 
   xmlns="http://www.w3.org/2000/svg"
 >
   <use href='{{this.contextRootURL}}@hashicorp/ember-flight-icons/icons/sprite.svg#{{@name}}-{{this.size}}'></use>

--- a/ember-flight-icons/tests/dummy/app/styles/app.css
+++ b/ember-flight-icons/tests/dummy/app/styles/app.css
@@ -84,7 +84,7 @@ ul.ds-ul-grid li.ds-li {
   align-items: center;
   display: flex;
   flex-direction: column;
-  font-size: 0.75em;
+  font-size: 1em;
   gap: 1ch;
   justify-content: center;
   padding: 0.5em 0.15em 0.15em;
@@ -97,24 +97,30 @@ ul.ds-ul-grid li.ds-li:hover {
   box-shadow: 0 0 0 1px var(--info-l1);
 }
 ul.ds-ul-grid li.ds-li .ds-icon-frame {
-  padding: 6px;
-  margin-top: auto;
-  display: flex;
+  align-items: center;
   background: white;
   border-radius: 2px;
   box-shadow: 0 0 0 1px var(--gray-5);
+  display: flex;
+  font-size: 1.5em;
+  justify-content: center;
+  margin-top: auto;
+  min-height: 50%;
+  min-width: 50%;
+  padding: 6px;
 }
 ul.ds-ul-grid li.ds-li:hover .ds-icon-frame {
-  color: var(--brand-link);
   box-shadow: 0 0 0 1px var(--info-l1);
+  color: var(--brand-link);
 }
-ul.ds-ul-grid li.ds-li p {
-  text-align: center;
+ul.ds-ul-grid li.ds-li p.ds-p {
+  font-size: 0.75em;
   margin-top: auto;
-  width: 100%;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
   white-space: nowrap;
+  width: 100%;
 }
 
 footer.ds-footer {
@@ -130,13 +136,4 @@ footer.ds-footer p.ds-p a.ds-a {
 
 .d-none {
   display: none !important;
-}
-
-/* test classes */
-.ds-text-red {
-  color: var(--danger-d1);
-}
-
-.ds-font-size-large {
-  font-size: 5em;
 }

--- a/ember-flight-icons/tests/dummy/app/templates/application.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/application.hbs
@@ -40,7 +40,7 @@
               class="demo-icon"
             />
           </div>
-          <p>{{meta.name}}</p>
+          <p class="ds-p">{{meta.name}}</p>
         </li>
       {{/each}}
     </ul>

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -28,18 +28,16 @@ module('Integration | Component | flight-icon', function (hooks) {
   // the component should render the 16x16 icon by default
   test('it renders the 16x16 icon by default', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
-    assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
-      height: '16px',
-      width: '16px',
-    });
+    assert
+      .dom('svg.flight-icon.icon-activity.display-inline')
+      .hasAttribute('viewBox', '0 0 16 16');
   });
   // the component should render the 24x24 icon if size is set
   test('it renders the 24x24 icon when option is set', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @size="24" />`);
-    assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
-      height: '24px',
-      width: '24px',
-    });
+    assert
+      .dom('svg.flight-icon.icon-activity.display-inline')
+      .hasAttribute('viewBox', '0 0 24 24');
   });
   // the component should not have a class of `display-inline` if that option has been set
   test('it does not have the display-inline class if the option is set to false', async function (assert) {


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR changes the `height` and `width` attributes to be `1em` so they are relational to their context. Fixes #30 

See https://codepen.io/melsumner/pen/1143304b4933a757d0a1e8233881bba7?editors=1100 for comparisons.

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.

## :hammer_and_wrench: Detailed Description

- changes component icon template
- updates tests
- updates dummy application template
- updates dummy application styles

