### PR TITLE
feature: added routes for design and engineering documentation

### DIFF
--- a/ember-flight-icons/tests/dummy/app/components/dummy-nav.hbs
+++ b/ember-flight-icons/tests/dummy/app/components/dummy-nav.hbs
@@ -1,0 +1,13 @@
+<nav class="ds-nav">
+  <ul class="ds-ul">
+    <li class="ds-li">
+      <a class="ds-a" href="/">View Icons</a>
+    </li>
+    <li class="ds-li">
+      <a class="ds-a" href="/design">Design</a>
+    </li>
+    <li class="ds-li">
+      <a class="ds-a" href="/engineering">Engineering</a>
+    </li>
+  </ul>
+</nav>

--- a/ember-flight-icons/tests/dummy/app/controllers/index.js
+++ b/ember-flight-icons/tests/dummy/app/controllers/index.js
@@ -1,0 +1,80 @@
+import Controller from '@ember/controller';
+import { action, set } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+const defaultSize = '24';
+
+const checkIsShown = function (searchText, meta) {
+  if (searchText === '') {
+    return true;
+  }
+
+  if (meta.searchable.indexOf(searchText) !== -1) {
+    return true;
+  }
+
+  return false;
+};
+
+export default class IndexController extends Controller {
+  @tracked selectedIcon = 'auto-apply';
+  @tracked size = '24';
+  @tracked color = 'currentColor';
+  @tracked searchText = '';
+
+  @tracked search;
+  @tracked emptyResults = false;
+
+  get iconHbsCode() {
+    let iconHbsCode = `<FlightIcon @name="${this.selectedIcon}"`;
+
+    if (this.size !== defaultSize) {
+      iconHbsCode += ` @size=${this.size}`;
+    }
+
+    if (this.color) {
+      iconHbsCode += ` @color="${this.color}"`;
+    }
+
+    iconHbsCode += '/>';
+
+    return iconHbsCode;
+  }
+
+  @action
+  async updateSearchText(value, signal) {
+    await new Promise((resolve) => setTimeout(resolve, 190));
+
+    if (signal.aborted) {
+      return;
+    }
+
+    this.search = value;
+    const lowcased = value.toLowerCase();
+
+    for (let i = 0; i < this.model.length; i++) {
+      const item = this.model[i];
+
+      set(item, 'isHidden', !checkIsShown(lowcased, item));
+    }
+
+    this.emptyResults = this.model.every(({ isHidden }) => isHidden);
+  }
+
+  @action
+  debouncedUpdate(event) {
+    if (this.ctrl) {
+      this.ctrl.abort();
+    }
+    this.ctrl = new AbortController();
+    this.updateSearchText(event.target.value, this.ctrl.signal);
+  }
+
+  @action
+  updateSelectedItem(event) {
+    const iconWrapper = event.target.closest('.demo-icon');
+    if (iconWrapper && iconWrapper.dataset.Name) {
+      this.selectedIcon = iconWrapper.dataset.Name;
+    }
+  }
+}

--- a/ember-flight-icons/tests/dummy/app/router.js
+++ b/ember-flight-icons/tests/dummy/app/router.js
@@ -6,4 +6,7 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function () {});
+Router.map(function () {
+  this.route('engineering');
+  this.route('design');
+});

--- a/ember-flight-icons/tests/dummy/app/routes/application.js
+++ b/ember-flight-icons/tests/dummy/app/routes/application.js
@@ -1,25 +1,3 @@
 import Route from '@ember/routing/route';
-import fetch from 'fetch';
-import { getOwner } from '@ember/application';
 
-export default class ApplicationRoute extends Route {
-  get contextRootURL() {
-    const config = getOwner(this).resolveRegistration('config:environment');
-    return config.rootURL || '/';
-  }
-
-  async model() {
-    const response = await fetch(
-      `${this.contextRootURL}@hashicorp/ember-flight-icons/icons/_catalog.json`
-    );
-    const json = await response.json();
-
-    return json.map(({ Name, Size }) => {
-      return {
-        name: `${Name}`,
-        size: `${Size}`,
-        searchable: `${Name}`,
-      };
-    });
-  }
-}
+export default class ApplicationRoute extends Route {}

--- a/ember-flight-icons/tests/dummy/app/routes/design.js
+++ b/ember-flight-icons/tests/dummy/app/routes/design.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class DesignRoute extends Route {}

--- a/ember-flight-icons/tests/dummy/app/routes/engineering.js
+++ b/ember-flight-icons/tests/dummy/app/routes/engineering.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class EngineeringRoute extends Route {}

--- a/ember-flight-icons/tests/dummy/app/routes/index.js
+++ b/ember-flight-icons/tests/dummy/app/routes/index.js
@@ -1,0 +1,25 @@
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+import { getOwner } from '@ember/application';
+
+export default class IndexRoute extends Route {
+  get contextRootURL() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return config.rootURL || '/';
+  }
+
+  async model() {
+    const response = await fetch(
+      `${this.contextRootURL}@hashicorp/ember-flight-icons/icons/_catalog.json`
+    );
+    const json = await response.json();
+
+    return json.map(({ Name, Size }) => {
+      return {
+        name: `${Name}`,
+        size: `${Size}`,
+        searchable: `${Name}`,
+      };
+    });
+  }
+}

--- a/ember-flight-icons/tests/dummy/app/styles/app.css
+++ b/ember-flight-icons/tests/dummy/app/styles/app.css
@@ -27,6 +27,38 @@ h1.ds-h1 {
   line-height: 1;
   padding: 0 0.5em;
 }
+header.ds-header nav.ds-nav {
+  display: flex;
+  flex-flow: row wrap;
+}
+header.ds-header nav.ds-nav ul.ds-ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+header.ds-header nav.ds-nav ul.ds-ul li.ds-li {
+  display: flex;
+  flex-flow: row wrap;
+}
+header.ds-header nav.ds-nav ul.ds-ul li.ds-li a.ds-a {
+  align-items: stretch;
+  border: 2px solid transparent;
+  color: white;
+  display: flex;
+  justify-content: center;
+  padding: 0.5em;
+}
+
+header.ds-header nav.ds-nav ul.ds-ul li.ds-li a.ds-a:focus {
+  border-color: white;
+  border-style: dashed;
+}
+header.ds-header nav.ds-nav ul.ds-ul li.ds-li a.ds-a:hover {
+  border-color: white;
+}
+
+
 main.ds-main {
   flex: 1 0 auto;
   padding: 0 1em 1em 1em;

--- a/ember-flight-icons/tests/dummy/app/templates/application.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/application.hbs
@@ -3,48 +3,10 @@
   <h1 id="title" class="ds-h1">
     Flight Icons
   </h1>
+  <DummyNav />
 </header>
 <main class="ds-main">
-  <p class="ds-p">
-    See the
-    <a
-      class="ds-a"
-      href="https://github.com/hashicorp/flight/blob/main/ember-flight-icons/README.md"
-    >README</a>
-    for usage instructions.
-  </p>
-  <section class="ds-section">
-    <h2 class="ds-h2">
-      Available Icon List
-    </h2>
-    <div class="ds-form-group-inline">
-      <label class="ds-input-label" for="ds-input-search">
-        Search to live-filter results:
-      </label>
-      <input
-        value={{this.search}}
-        placeholder="e.g. arrow"
-        autofocus={{false}}
-        class="ds-input"
-        id="ds-input-search search-field"
-        {{on 'input' this.debouncedUpdate}}
-      />
-    </div>
-    <ul class="ds-ul-grid">
-      {{#each @model as |meta|}}
-        <li class="ds-li {{if meta.isHidden 'd-none'}}">
-          <div class="ds-icon-frame">
-            <FlightIcon
-              @name={{Onlyname meta.name}}
-              @size={{if (eq meta.size '24') '24'}}
-              class="demo-icon"
-            />
-          </div>
-          <p>{{meta.name}}</p>
-        </li>
-      {{/each}}
-    </ul>
-  </section>
+  {{outlet}}
 </main>
 <footer class="ds-footer">
   <p class="ds-p">

--- a/ember-flight-icons/tests/dummy/app/templates/design.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/design.hbs
@@ -1,0 +1,2 @@
+{{page-title "Design"}}
+<h2 class="ds-h2">For Designers</h2>

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -1,0 +1,10 @@
+{{page-title "Engineering"}}
+<h2 class="ds-h2">For Engineers</h2>
+<p class="ds-p">
+    See the
+    <a
+      class="ds-a"
+      href="https://github.com/hashicorp/flight/blob/main/ember-flight-icons/README.md"
+    >README</a>
+    for usage instructions.
+  </p>

--- a/ember-flight-icons/tests/dummy/app/templates/index.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,33 @@
+{{page-title "Index"}}
+  <section class="ds-section">
+    <h2 class="ds-h2">
+      Available Icon List
+    </h2>
+    <div class="ds-form-group-inline">
+      <label class="ds-input-label" for="ds-input-search">
+        Search to live-filter results:
+      </label>
+      <input
+        value={{this.search}}
+        placeholder="e.g. arrow"
+        autofocus={{false}}
+        class="ds-input"
+        id="ds-input-search search-field"
+        {{on 'input' this.debouncedUpdate}}
+      />
+    </div>
+    <ul class="ds-ul-grid">
+      {{#each @model as |meta|}}
+        <li class="ds-li {{if meta.isHidden 'd-none'}}">
+          <div class="ds-icon-frame">
+            <FlightIcon
+              @name={{Onlyname meta.name}}
+              @size={{if (eq meta.size '24') '24'}}
+              class="demo-icon"
+            />
+          </div>
+          <p>{{meta.name}}</p>
+        </li>
+      {{/each}}
+    </ul>
+  </section>


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR resolves issue #121 

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.

## :hammer_and_wrench: Detailed Description

- added `design` and `engineering` routes to dummy app
- added navbar component to dummy app
- added styles to support navbar to dummy app
- added an `index` template to dummy app
- moved some of the application template code to the index template 
- moved controller code from application controller to index controller
- moved the router code from the application router to the index router

Needs more styling for the navbar, not sure what would be consistent and cycles are waning for today. Will pick it up again tomorrow.