### PR TITLE
add default title to docs app

### DIFF
--- a/ember-flight-icons/tests/dummy/app/index.html
+++ b/ember-flight-icons/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>Flight Icons</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
## :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

Currently there is a brief moment during load where the title of the page is `Dummy`. This PR changes that to `Flight Icons`.


