### PR TITLE
move conventional comments prompt to bottom

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,13 +4,6 @@
 This should be a short TL;DR that includes the purpose of the PR.
 -->
 
-### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
-
-Examples: 
-- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
-- suggestion (non-blocking): Let's change this wording to make it easier to understand.
-- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
-
 ## :hammer_and_wrench: Detailed Description
 
 <!-- If more details are appropriate, add them here. What code changed, and why? -->
@@ -35,3 +28,10 @@ Examples:
 - [ ] Accessibility addressed
 - [ ] Tests added
 - [ ] Docs updated
+
+### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
+
+Examples: 
+- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
+- suggestion (non-blocking): Let's change this wording to make it easier to understand.
+- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.


### PR DESCRIPTION
## :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

While filling out a PR with this template it's distracting having a large section of text that is for the reviewer mixed in with content that the PR author needs to fill out. To try to help with this I propose we move that section to the. bottom as the last thing a reviewer would read before looking at the PR.

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
