### PR TITLE
fix: update displayed name

### DIFF
--- a/ember-flight-icons/tests/dummy/app/templates/index.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/index.hbs
@@ -26,7 +26,7 @@
               class="demo-icon"
             />
           </div>
-          <p>{{meta.name}}</p>
+          <p>{{Onlyname meta.name}}</p>
         </li>
       {{/each}}
     </ul>


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR changes the display name on the icon to only show the name

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.

