### PR TITLE
enhancement: consumer instructions for engineers

### DIFF
--- a/ember-flight-icons/tests/dummy/app/styles/app.css
+++ b/ember-flight-icons/tests/dummy/app/styles/app.css
@@ -67,6 +67,7 @@ p.ds-p {
   font-family: var(--font-body);
   font-size: 1em;
   line-height: 1.2;
+  margin: 0.25vh auto;
 }
 h2.ds-h2 {
   border-bottom: 1px solid var(--gray-5);
@@ -74,6 +75,18 @@ h2.ds-h2 {
   line-height: 1;
   padding-bottom: 0.75em;
 }
+h2.ds-h2,
+h3.ds-h3,
+h4.ds-h4,
+h5.ds-h5 {
+  font-family: var(--font-display);
+}
+
+h5.ds-h5 {
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
 
 .ds-form-group-inline {
   display: flex;
@@ -81,9 +94,9 @@ h2.ds-h2 {
   margin-bottom: 1.5em;
 }
 .ds-form-group-inline label.ds-input-label {
+  color: var(--code-dark);
   font-family: var(--font-body);
   font-weight: var(--font-weight-semi-bold);
-  color: var(--code-dark);
   margin-bottom: 0.75em;
 }
 .ds-form-group-inline input.ds-input {
@@ -152,23 +165,48 @@ ul.ds-ul-grid li.ds-li p {
 footer.ds-footer {
   background-color: var(--brand);
   color: white;
+  display: flex;
+  flex-flow: row wrap;
   flex-shrink: 0;
+  justify-content: flex-start;
+  min-height: 50px;
 }
 
 footer.ds-footer p.ds-p a.ds-a {
+  align-items: stretch;
   color: white;
+  display: flex;
+  justify-content: center;
   padding: 0.5em 1em;
 }
+
 
 .d-none {
   display: none !important;
 }
 
-/* test classes */
-.ds-text-red {
-  color: var(--danger-d1);
+.ds-code {
+  background-color: var(--gray-7);
+  border: 1px solid var(--gray-5);
+  border-radius: 4px;
+  display: block;
+  font-size: 0.9em;
+  margin: 0.25vh auto 1vh;
+  padding: 0.75em;
+}
+.ds-kbd {
+  color: rebeccapurple;
+  font-size: 0.9em;
+  font-weight: var(--font-weight-bold);
 }
 
-.ds-font-size-large {
-  font-size: 5em;
+.ds-rotate-90 {
+  transform: rotate(90deg);
+}
+
+.ds-info {
+  background-color: var(--info-l2);
+  border: 1px solid var(--brand);
+  border-radius: 4px;
+  padding: 0.75em;
 }

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -1,10 +1,87 @@
 {{page-title "Engineering"}}
-<h2 class="ds-h2">For Engineers</h2>
-<p class="ds-p">
-    See the
-    <a
-      class="ds-a"
-      href="https://github.com/hashicorp/flight/blob/main/ember-flight-icons/README.md"
-    >README</a>
-    for usage instructions.
-  </p>
+<h2 class="ds-h2">Consumer instructions</h2>
+<p>There are multiple ways to use these icons in your codebase.</p>
+
+<div class="ds-info">
+<p class="ds-p">🚨 Note: All of the flight-icon npm packages are currently in beta and any production usage should be discussed with the Design Systems team first.</p>
+</div>
+
+<h3 class="ds-h3" id="ember-flight-icons"><a href="#ember-flight-icons">&sect;</a> Use in Ember Apps</h3>
+<h4 class="ds-h4">Installation</h4>
+<p class="ds-p">To install, run
+<code class="ds-code">yarn add @hashicorp/ember-flight-icons</code>
+</p>
+
+<h4 class="ds-h4" id="understanding"><a href="#understanding">&sect;</a> Understanding the component</h4>
+
+<p class="ds-p">The component comes with the following defaults:
+<ul class="ds-ul">
+  <li class="ds-li">fill (set to currentColor)</li>
+  <li class="ds-li">a unique, automatically generated id</li>
+  <li class="ds-li">aria-hidden (set to true)</li>
+  <li class="ds-li">default size of 16x16 (px)</li>
+  <li class="ds-li">CSS class (flight-icon & icon-NAME)</li>
+  <li class="ds-li">data-test-icon attribute (for test purposes)</li>
+</ul>
+</p>
+
+<p class="ds-p">This makes the base, required invocation quite terse- <kbd class="ds-kbd">@name</kbd> is the only property that requires specification.
+
+<br>So this invocation:
+<pre><code class="ds-code">&lt;FlightIcon @name="alert-circle" /></code></pre>
+Renders to this:
+<pre><code class="ds-code">
+&lt;svg 
+  aria-hidden="true" 
+  class="flight-icon icon-alert-circle display-inline" 
+  data-test-icon
+  fill="currentColor" 
+  height="16" 
+  id="icon-ember115" 
+  viewBox="0 0 16 16" 
+  width="16" 
+  xmlns="http://www.w3.org/2000/svg">
+    &lt;use href="/@hashicorp/ember-flight-icons/icons/sprite.svg#alert-circle-16">&lt;/use>
+&lt;/svg>
+</code>
+</pre>
+</p>
+<p class="ds-p">The <kbd class="ds-kbd">`use`</kbd> element will then render the correct svg to the shadow dom.</p>
+
+<h4 class="ds-h4" id="customizable"><a href="#customizable">&sect;</a> Customizable properties</h4>
+<p class="ds-p">The following properties are customizable:
+  <ul class="ds-ul">
+    <li class="ds-li">fill</li>
+    <li class="ds-li">height/width/viewBox (at this time, only 16 (default) and 24 are supported)</li>
+    <li class="ds-li">additional CSS classes</li>
+  </ul>
+</p>
+<h5 class="ds-h5">Examples</h5>
+<p class="ds-p" id="example-fill">
+  <strong>Fill:</strong> To customize the fill attribute, set the <kbd class="ds-kbd">`@color`</kbd> value (multiple supported ways):
+  <pre><code class="ds-code">
+  &lt;FlightIcon @name="zap" @color="var(--brand)" /> <FlightIcon @name="zap" @color="var(--brand)" />
+
+  &lt;FlightIcon @name="zap" @color="rebeccapurple" /> <FlightIcon @name="zap" @color="rebeccapurple" />
+
+  &lt;FlightIcon @name="zap" @color="rgb(46, 113, 229)" /> <FlightIcon @name="zap" @color="rgb(46, 113, 229)" />
+  </code></pre>
+</p>
+<p class="ds-p" id="example-size">
+  <strong>Size:</strong> To use the 24x24 (px) icon size, set the <kbd class="ds-kbd">`@size`</kbd> value:
+  <pre><code class="ds-code">&lt;FlightIcon @name="zap" @size="24" /> <FlightIcon @name="zap" @size="24" /></code></pre>
+</p>
+<p class="ds-p" id="example-styles">
+  <strong>CSS Classes:</strong> To append additional classes to the component, add <kbd class="ds-kbd">`class`</kbd> with value(s):
+  <pre><code class="ds-code">&lt;FlightIcon @name="triangle-fill" class="ds-rotate-90" /> <FlightIcon @name="triangle-fill" class="ds-rotate-90" /></code></pre>
+</p>
+<hr/>
+
+<h3 class="ds-h3" id="use-other"><a href="#use-other">&sect;</a> Using the flight-icon package in other ways</h3>
+<p class="ds-h3">
+  It is also possible to install the flight-icon package itself. 
+  To do so, run:
+<pre><code class="ds-code">yarn install @hashicorp/flight-icons</code></pre>
+This will allow icons to be imported and used as desired. Note that the icons are namespaced:
+<pre><code class="ds-code">@hashicorp/flight-icons/icons/arrow-right-16.svg</code></pre>
+</p>


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR adds consumer instructions for engineers. Note: this is a diversion from the original plan, after discovering that it wasn't quite possible yet ([see related issue](https://github.com/gcollazo/ember-cli-showdown/issues/54))

 :speech_balloon:  Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.

## :hammer_and_wrench: Detailed Description

- [ ] added markdown to the engineer.hbs file
- [ ] added supporting styles (all classes are prefixed with `.ds-` to avoid naming collisions)
- [ ] removed duplicate info from README files and link to this file instead

adding instructions for designers may be done in a separate PR.

## :camera_flash: Screenshots

Visit the deploy preview directly: https://flight-git-feature-update-docs-hashicorp.vercel.app/engineering 
