### PR TITLE
bugfix: resolve issue where not all the css classes were namespaced

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -1,13 +1,13 @@
 <svg 
-  class="flight-icon icon-{{@name}} {{if this.display "display-inline"}}"
+  class="flight-icon flight-icon-{{@name}} {{if this.display "flight-icon-display-inline"}}"
   ...attributes
   aria-hidden="true"
   data-test-icon
   fill="{{this.color}}"
-  height="{{this.size}}"
   id={{this.iconId}}
-  viewBox="0 0 {{this.size}} {{this.size}}"
+  height="{{this.size}}"
   width="{{this.size}}" 
+  viewBox="0 0 {{this.size}} {{this.size}}"
   xmlns="http://www.w3.org/2000/svg"
 >
   <use href='{{this.contextRootURL}}@hashicorp/ember-flight-icons/icons/sprite.svg#{{@name}}-{{this.size}}'></use>

--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -5,8 +5,8 @@
   data-test-icon
   fill="{{this.color}}"
   id={{this.iconId}}
+  width="{{this.size}}"
   height="{{this.size}}"
-  width="{{this.size}}" 
   viewBox="0 0 {{this.size}} {{this.size}}"
   xmlns="http://www.w3.org/2000/svg"
 >

--- a/ember-flight-icons/addon/styles/app.css
+++ b/ember-flight-icons/addon/styles/app.css
@@ -1,4 +1,4 @@
-.flight-icon.display-inline {
+.flight-icon.flight-icon-display-inline {
   display: inline-block;
 }
 .flight-icon {

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | flight-icon', function (hooks) {
   test('it renders the icon', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert
-      .dom('svg.flight-icon.icon-activity.display-inline')
+      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
       .matchesSelector('svg');
   });
   test('it should have a class name that is the same as the component name', async function (assert) {
@@ -19,22 +19,26 @@ module('Integration | Component | flight-icon', function (hooks) {
   test('it has aria-hidden set to true', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert
-      .dom('svg.flight-icon.icon-activity.display-inline')
+      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
       .hasAttribute('aria-hidden');
   });
   test('it renders the 16x16 icon by default', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
-    assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
-      height: '16px',
-      width: '16px',
-    });
+    assert
+      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
+      .hasStyle({
+        height: '16px',
+        width: '16px',
+      });
   });
   test('it renders the 24x24 icon when option is set', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @size="24" />`);
-    assert.dom('svg.flight-icon.icon-activity.display-inline').hasStyle({
-      height: '24px',
-      width: '24px',
-    });
+    assert
+      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
+      .hasStyle({
+        height: '24px',
+        width: '24px',
+      });
   });
   test('it does not have the display-inline class if the option is set to false', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @isInlineBlock={{false}} />`);


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR resolves #150 by adding additional namespacing to the component css classes. I also re-arranged the properties in the component itself so height/width/viewbox were grouped together, for easier maintenance (based on feedback from @didoo). 

After this PR and PR #149 are merged, I'll update the documentation and the README files to align.

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
