### PR TITLE
drop support for node 10

### DIFF
--- a/.github/workflows/ci-ember-flight-icons.yml
+++ b/.github/workflows/ci-ember-flight-icons.yml
@@ -24,7 +24,7 @@
 #$   - scenario: ember-classic
 #$   - scenario: embroider-safe
 #$   - scenario: embroider-optimized
-#$ nodeVersion: 10.x
+#$ nodeVersion: 12.x
 #$ packageManager: yarn
 #
 
@@ -40,7 +40,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '10.x'
+  NODE_VERSION: '12.x'
 
 jobs:
   lint:

--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -96,7 +96,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || >= 14"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

ember-cli has dropped support for this, it's been EOL for some time and I believe we can drop support for it as well as I'm not aware of any consumer apps on a node version this old (and if they are they should probably upgrade!)