### PR TITLE
allow embroiderSafe to fail

### DIFF
--- a/ember-flight-icons/config/ember-try.js
+++ b/ember-flight-icons/config/ember-try.js
@@ -76,7 +76,7 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafe(),
+      embroiderSafe({ allowedToFail: true }),
       embroiderOptimized({ allowedToFail: true }),
     ],
   };


### PR DESCRIPTION
Known issue with ember-cli-postcss https://github.com/embroider-build/embroider/issues/688

I think it would be worth consdiering either not running this step at all since allowing it to fail is effectively the same thing or extracting out the docs so issues with them don't affect our ability ensure embroider compat for consumers of the addon itself.