### PR TITLE
header and hero updates per design review

### DIFF
--- a/ember-flight-icons/tests/dummy/app/styles/nav.css
+++ b/ember-flight-icons/tests/dummy/app/styles/nav.css
@@ -6,7 +6,8 @@ header.ds-header nav.ds-nav {
   min-w-full
   max-w-7xl 
   mx-auto 
-  md:px-8
+  md:pr-8
+  md:pl-32
   sm:px-4 
   shadow;
 }
@@ -22,8 +23,7 @@ header.ds-header nav.ds-nav ul.ds-ul {
 header.ds-header nav.ds-nav ul.ds-ul li.ds-li {
   @apply 
   flex
-  items-stretch
-  w-24;
+  items-stretch;
 }
 
 header.ds-header nav.ds-nav ul.ds-ul li.ds-li a.ds-a {
@@ -37,13 +37,16 @@ header.ds-header nav.ds-nav ul.ds-ul li.ds-li a.ds-a {
   justify-center
   items-center 
   pt-1 
-  px-1 
+  px-4
   text-base;
 }
 
-header.ds-header nav.ds-nav ul.ds-ul li.ds-li a.ds-a:focus {
-  border-color: white;
-}
+header.ds-header nav.ds-nav ul.ds-ul li.ds-li a.ds-a:focus,
 header.ds-header nav.ds-nav ul.ds-ul li.ds-li a.ds-a:hover {
   border-color: white;
+}
+
+header.ds-header nav.ds-nav ul.ds-ul li.ds-li:first-of-type a.ds-a:focus,
+header.ds-header nav.ds-nav ul.ds-ul li.ds-li:first-of-type a.ds-a:hover {
+  border-color: transparent;
 }

--- a/ember-flight-icons/tests/dummy/app/styles/typography.css
+++ b/ember-flight-icons/tests/dummy/app/styles/typography.css
@@ -9,38 +9,48 @@ a.ds-a {
   color: var(--brand-link);
 }
 
-h1.ds-h1
+h1.ds-h1,
+.ds-h1,
 h2.ds-h2,
+.ds-h2,
 h3.ds-h3,
+.ds-h3,
 h4.ds-h4,
-h5.ds-h5 {
+.ds-h4,
+h5.ds-h5,
+.ds-h5 {
   font-family: var(--font-display);
   line-height: var(--font-line-height-headings);
 }
 
-h1.ds-h1 {
+h1.ds-h1,
+.ds-h1 {
   @apply 
   mb-4
   text-3xl
   ;
 }
 
-h2.ds-h2 {
+h2.ds-h2,
+.ds-h2 {
   @apply
   text-2xl;
 }
 
-h3.ds-h3 {
+h3.ds-h3,
+.ds-h3 {
   @apply 
   text-xl 
   font-medium;
 
 }
 
-h4.ds-h4 {
+h4.ds-h4,
+.ds-h4 {
   @apply text-lg;
 }
 
-h5.ds-h5 {
+h5.ds-h5,
+.ds-h5 {
   @apply text-base;
 }

--- a/ember-flight-icons/tests/dummy/app/templates/index.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/index.hbs
@@ -5,57 +5,55 @@
 {{!-- TODO this can't go from an h1 to an h3 --}}
 <div class="rounded-lg mb-8 bg-gray-200 overflow-hidden shadow divide-y divide-gray-200 sm:divide-y-0 sm:grid sm:grid-cols-2 sm:gap-px">
   <div class="rounded-tl-lg rounded-tr-lg sm:rounded-tr-none relative group bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-brand">
-    <h3 class="ds-h3 mb-2">
-      <LinkTo @route="design" class="ds-a focus:outline-none">
-        <span class="absolute inset-0" aria-hidden="true"></span>
-        <FlightIcon @name="path" @size="24" @color="var(--brand)" class="sm:mr-0 md:mr-2 lg:mr-4" /> Getting Started for Design
-      </LinkTo>
-    </h3>
-    <p class="ds-p">
+    <LinkTo @route="design" class="ds-a ds-h3 mb-4 focus:outline-none hover:underline">
+      <span class="absolute inset-0" aria-hidden="true"></span>
+      <FlightIcon @name="path" @size="24" @color="var(--brand)" class="sm:mr-0 md:mr-2 lg:mr-4" /> 
+      Getting Started for Design
+    </LinkTo>
+    <p class="ds-p lg:pl-12">
       Bring Flight into your Figma files, contribute a new icon, or learn about design best practices.
     </p>
   </div>
 
   <div class="sm:rounded-tr-lg relative group bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-brand">
-    <h3 class="ds-h3 mb-2">
-        <LinkTo @route="engineering" class="ds-a focus:outline-none">
-        <!-- Extend touch target to entire panel -->
-        <span class="absolute inset-0" aria-hidden="true"></span>
-        <FlightIcon @name="code" @size="24" @color="var(--brand)" class="sm:mr-0 md:mr-2 lg:mr-4" /> Getting Started For Engineers
-      </LinkTo>
-    </h3>
-    <p class="ds-p mt-2">
-      Learn how to implement Flight icons into your project with options for direct SVG support or as an Ember addon.    </p>
+    <LinkTo @route="engineering" class="ds-a ds-h3 mb-4 focus:outline-none hover:underline">
+      <!-- Extend touch target to entire panel -->
+      <span class="absolute inset-0" aria-hidden="true"></span>
+      <FlightIcon @name="code" @size="24" @color="var(--brand)" class="sm:mr-0 md:mr-2 lg:mr-4" /> 
+      Getting Started For Engineers
+    </LinkTo>
+    <p class="ds-p lg:pl-12">
+      Learn how to implement Flight icons into your project with options for direct SVG support or as an Ember addon.
+    </p>
   </div>
 
   <div class="relative group bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-brand">
-    <h3 class="ds-h3">
-        <a href="" class="ds-a focus:outline-none">
-        <!-- Extend touch target to entire panel -->
-        <span class="absolute inset-0" aria-hidden="true"></span>
-        <FlightIcon @name="edit" @size="24" @color="var(--brand)" class="sm:mr-0 md:mr-2 lg:mr-4" /> Contributing Guide
-      </a>
-    </h3>
+    <a href="" class="ds-a ds-h3 focus:outline-none hover:underline">
+      <!-- Extend touch target to entire panel -->
+      <span class="absolute inset-0" aria-hidden="true"></span>
+      <FlightIcon @name="edit" @size="24" @color="var(--brand)" class="sm:mr-0 md:mr-2 lg:mr-4" /> 
+      Contributing Guide
+    </a>
   </div>
 
   <div class="relative group bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-brand">
-    <h3 class="ds-h3">
-      <a href="#" class="ds-a focus:outline-none">
+      <a href="https://github.com/hashicorp/flight" class="ds-a ds-h3 focus:outline-none hover:underline" rel="external">
         <!-- Extend touch target to entire panel -->
         <span class="absolute inset-0" aria-hidden="true"></span>
-        <FlightIcon @name="git-pull-request" @size="24" @color="var(--brand)" class="sm:mr-0 md:mr-2 lg:mr-4" /> GitHub Repository
+        <FlightIcon @name="git-pull-request" @size="24" @color="var(--brand)" class="sm:mr-0 md:mr-2 lg:mr-4" /> 
+        GitHub Repository
       </a>
-    </h3>
   </div>
 
 </div>
 
 
 
-  <section class="ds-section">
+  <section class="ds-section" aria-labelledby="available-icons">
+    <h2 class="ds-h2" id="available-icons">Available Icons</h2>
     <div class="ds-form-group-inline">
       <label class="ds-input-label" for="ds-input-search">
-        Search (to filter results)
+        Filter Results
       </label>
       <input
         value={{this.search}}
@@ -66,7 +64,7 @@
         {{on 'input' this.debouncedUpdate}}
       />
     </div>
-    <h2 class="ds-h2">Available Icons</h2>
+    
     <ul class="ds-ul-grid">
       {{#each @model as |meta|}}
         <li class="ds-li {{if meta.isHidden 'd-none'}}">


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR makes some updates to the header and hero area based on design review.

## :hammer_and_wrench: Detailed Description

- removed underline from HC logo on hover
- added underline to grid links on hover
- removed h3's
- spaced out the navbar more to balance it out a bit more
- aligned the grid paragraph text to be under the text only (not the icon)

## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/4587451/132739106-54169472-3eca-4d15-909d-ae6f35846cb8.png)


### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
