### PR TITLE
add simple acceptance test to confirm docs are rendering icons

### DIFF
--- a/ember-flight-icons/tests/acceptance/index-test.js
+++ b/ember-flight-icons/tests/acceptance/index-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | icon index', function (hooks) {
+  setupApplicationTest(hooks);
+
+  // sanity checking that the docs are doing something vaguely resembling what we expect
+  test('visiting / renders a list of icons', async function (assert) {
+    await visit('/');
+
+    assert.dom('[data-test-target="icon-grid"] [data-test-icon]').exists();
+  });
+});

--- a/ember-flight-icons/tests/dummy/app/templates/index.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/index.hbs
@@ -16,7 +16,7 @@
         {{on 'input' this.debouncedUpdate}}
       />
     </div>
-    <ul class="ds-ul-grid">
+    <ul class="ds-ul-grid" data-test-target="icon-grid">
       {{#each @model as |meta|}}
         <li class="ds-li {{if meta.isHidden 'd-none'}}">
           <div class="ds-icon-frame">


### PR DESCRIPTION
## :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->

The goal of this PR is to give a simple test to confirm that the docs are rendering at least one icon in the list of icons. This will help guard against any unintended breakage as we refactor how we are ingesting the catalog.json file.

