### PR TITLE
enhancement: add toggle button

### DIFF
--- a/ember-flight-icons/tests/dummy/app/components/ds-toggle-button.hbs
+++ b/ember-flight-icons/tests/dummy/app/components/ds-toggle-button.hbs
@@ -1,0 +1,25 @@
+<button
+  aria-checked="false"
+  aria-label="Toggle icon size (16 or 24)"
+  class="ds-toggle-button"
+  role="switch"
+  type="button"
+  {{on 'click' this.updateVisibleIconSize}}
+>
+  <!-- Enabled: "translate-x-5", Not Enabled: "translate-x-0" -->
+  <span class="ds-toggle-button-slider">
+    <!-- Enabled: "opacity-0 ease-out duration-100", Not Enabled: "opacity-100 ease-in duration-200" -->
+    <span 
+    class="ds-toggle-16 {{if (eq this.visibleIconSize '16') "ds-toggle-16-active"}}" 
+    aria-hidden="true">
+      16px
+    </span>
+    <!-- Enabled: "opacity-100 ease-in duration-200", Not Enabled: "opacity-0 ease-out duration-100" -->
+    <span 
+    class="ds-toggle-24 {{if (eq this.visibleIconSize '24') "ds-toggle-24-active"}}" 
+    aria-hidden="true">
+      24px
+    </span>
+  </span>
+
+</button>

--- a/ember-flight-icons/tests/dummy/app/components/ds-toggle-button.js
+++ b/ember-flight-icons/tests/dummy/app/components/ds-toggle-button.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class DsToggleButtonComponent extends Component {
+  @tracked visibleIconSize = '16';
+
+  @action
+  updateVisibleIconSize() {
+    if (this.visibleIconSize === '16') {
+      this.visibleIconSize = '24';
+    } else {
+      this.visibleIconSize = '16';
+    }
+    // TODO take this out before publishing
+    console.log(`visibleIconSize is ${this.visibleIconSize}`);
+  }
+}

--- a/ember-flight-icons/tests/dummy/app/controllers/application.js
+++ b/ember-flight-icons/tests/dummy/app/controllers/application.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action, set } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-const defaultSize = '24';
+const defaultSize = '16';
 
 const checkIsShown = function (searchText, meta) {
   if (searchText === '') {
@@ -18,7 +18,7 @@ const checkIsShown = function (searchText, meta) {
 
 export default class ApplicationController extends Controller {
   @tracked selectedIcon = 'auto-apply';
-  @tracked size = '24';
+  @tracked size = '16';
   @tracked color = 'currentColor';
   @tracked searchText = '';
 

--- a/ember-flight-icons/tests/dummy/app/routes/index.js
+++ b/ember-flight-icons/tests/dummy/app/routes/index.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
 import fetch from 'fetch';
 import { getOwner } from '@ember/application';
+import { tracked } from '@glimmer/tracking';
 
 export default class IndexRoute extends Route {
+  @tracked visibleIconSize = 16;
+
   get contextRootURL() {
     const config = getOwner(this).resolveRegistration('config:environment');
     return config.rootURL || '/';

--- a/ember-flight-icons/tests/dummy/app/styles/app.css
+++ b/ember-flight-icons/tests/dummy/app/styles/app.css
@@ -121,3 +121,99 @@ img.ds-img {
   height: auto;
   max-width: 100%;
 }
+
+
+/* Once this has been figured out, replace with TW classes */
+.this-is-the-row {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+}
+.this-is-the-search {
+  min-width: 80%;
+}
+.this-is-the-toggle {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+}
+/* TODO remove any unnecessary TW classes, convert current CSS into TW*/
+button.ds-toggle-button {
+  background-color: var(--brand);
+  color: var(--white);
+  font-weight: var(--font-weight-bold);
+  height: 2.5rem;
+  width: 8rem;
+  box-sizing: border-box; 
+  @apply
+  inline-flex 
+  border-2 
+  border-transparent 
+  rounded-full 
+  cursor-pointer 
+  transition-colors 
+  ease-in-out 
+  duration-200 
+  focus:outline-none 
+  focus:ring-2 
+  focus:ring-offset-2 
+  focus:ring-brand;
+}
+
+/* TODO remove any unnecessary TW classes, convert current CSS into TW*/
+.ds-toggle-button .ds-toggle-button-slider {
+  display: flex;
+  justify-content:space-evenly;
+  color: var(--brand);
+  height: 2.25rem;
+  width: 8rem;
+  background-color: transparent;
+  box-sizing: border-box; 
+  @apply
+  pointer-events-none  
+  rounded-full 
+  shadow 
+  transform 
+  ring-0;
+}
+
+/* TODO remove any unnecessary TW classes, convert current CSS into TW*/
+.ds-toggle-16 {
+  color: var(--white);
+  width: 50%;
+  box-sizing: border-box; 
+  @apply 
+  ease-in 
+  duration-200 
+  inset-0 
+  flex 
+  items-center 
+  justify-center 
+  transition-opacity
+  rounded-full;
+}
+.ds-toggle-16.ds-toggle-16-active {
+  color: var(--brand);
+  height: 2.25rem;
+  width: 50%;
+  background-color: white;
+  @apply
+  rounded-full;
+}
+/* TODO remove any unnecessary TW classes, convert current CSS into TW*/
+.ds-toggle-24 {
+  background-color: transparent;
+  color: var(--white);
+  min-width: 4rem;
+  box-sizing: border-box; 
+  @apply 
+  rounded-full ease-out duration-100 inset-0 flex items-center justify-center transition-opacity;
+}
+.ds-toggle-24.ds-toggle-24-active {
+  color: var(--brand);
+  height: 2.25rem;
+  width: 4rem;
+  background-color: white;
+  @apply
+  rounded-full;
+}

--- a/ember-flight-icons/tests/dummy/app/templates/index.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/index.hbs
@@ -48,33 +48,37 @@
 
 <section class="ds-section" aria-labelledby="available-icons">
   <h2 class="ds-h2 mb-3" id="available-icons">Available Icons</h2>
-
-  <div class="mb-14">
-    <label for="ds-input-search" class="block font-medium text-gray-2">Filter Results</label>
-    <div class="mt-1 relative rounded-md shadow-sm">
-    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-      <FlightIcon @name="search" @color="var(--gray-3)" />
+  <div class="this-is-the-row flex mb-14">
+    <div class="this-is-the-search">
+      <label for="ds-input-search" class="block font-medium text-gray-2">Filter Results</label>
+      <div class="mt-1 relative rounded-md shadow-sm">
+      <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <FlightIcon @name="search" @color="var(--gray-3)" />
+      </div>
+        <input 
+        type="text" 
+        name="search" 
+        id="ds-input-search" 
+        class="shadow-sm focus:ring-brand focus:border-brand block w-full pl-10 sm:text-sm border-gray-300 rounded-md" 
+        placeholder="e.g. arrow"
+        autofocus={{false}}
+        value={{this.search}}
+        {{on 'input' this.debouncedUpdate}}
+        >
+      </div>
     </div>
-      <input 
-      type="text" 
-      name="search" 
-      id="ds-input-search" 
-      class="shadow-sm focus:ring-brand focus:border-brand block w-full pl-10 sm:text-sm border-gray-300 rounded-md" 
-      placeholder="e.g. arrow"
-      autofocus={{false}}
-      value={{this.search}}
-      {{on 'input' this.debouncedUpdate}}
-      >
+    <div class="this-is-the-toggle">
+      <!-- Enabled: "bg-indigo-600", Not Enabled: "bg-gray-200" -->
+      <DsToggleButton />
     </div>
   </div>
-  
   <ul class="ds-ul-grid">
     {{#each @model as |meta|}}
       <li class="ds-li {{if meta.isHidden 'd-none'}}">
         <div class="ds-icon-frame">
           <FlightIcon
             @name={{Onlyname meta.name}}
-            @size={{if (eq meta.size '24') '24'}}
+            @size="{{meta.size}}"
             class="demo-icon"
           />
         </div>


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR resolves #169 by adding the toggle button for the icon size.

## :camera_flash: Screenshots

So far: 
![image](https://user-images.githubusercontent.com/4587451/132880257-0d924f28-ac29-4dd3-ac11-e44bb820a244.png)
![image](https://user-images.githubusercontent.com/4587451/132880312-e8c7e9d0-069a-43b1-a9c4-934362472bad.png)


### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
