### PR TITLE
updated eng docs to use same layout classes as design docs

### DIFF
--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -1,21 +1,25 @@
 {{page-title "Engineering Guidelines"}}
 <h1 class="ds-h1">Consumer instructions</h1>
-<p>There are multiple ways to use these icons in your codebase. The <a href="#use-other">package itself can be consumed</a> for direct import, or it can be installed as an <a href="#ember-flight-icons">Ember addon</a> for the convenience of using a component with strong defaults.</p>
-
-<div class="ds-info">
-<p class="ds-p">🚨 Note: All of the flight-icon npm packages are currently in beta and any production usage should be discussed with the Design Systems team first.</p>
+<div class="mt-8 prose prose-lg text-gray-800 pb-6">
+<p>There are multiple ways to use these icons in your codebase. The <a href="#use-other" class="ds-a">package itself can be consumed</a> for direct import, or it can be installed as an <a href="#ember-flight-icons" class="ds-a">Ember addon</a> for the convenience of using a component with strong defaults.</p>
 </div>
 
-<h2 class="ds-h2" id="ember-flight-icons"><a href="#ember-flight-icons">&sect;</a> Use in Ember Apps</h2>
+<div class="ds-info">
+<p >🚨 Note: All of the flight-icon npm packages are currently in beta and any production usage should be discussed with the Design Systems team first.</p>
+</div>
+
+<div class="mt-8 prose prose-lg text-gray-800 pb-6">
+<h2 class="ds-h2" id="ember-flight-icons"><a href="#ember-flight-icons" class="ds-a" rel="external">&sect;</a> Use in Ember Apps</h2>
 <h3 class="ds-h3">Installation</h3>
-<p class="ds-p">To install, run
+<p >To install, run
 <code class="ds-code">yarn add @hashicorp/ember-flight-icons</code>
 </p>
+</div>
+<div class="mt-8 prose prose-lg text-gray-800 pb-6">
+<h3 class="ds-h3" id="understanding"><a href="#understanding" class="ds-a" rel="external">&sect;</a> Understanding the component</h3>
 
-<h3 class="ds-h3" id="understanding"><a href="#understanding">&sect;</a> Understanding the component</h3>
-
-<p class="ds-p">The component comes with the following defaults:
-<ul class="ds-ul">
+<p >The component comes with the following defaults:
+<ol>
   <li class="ds-li"><kbd class="ds-kbd">fill</kbd> attribute: set to currentColor</li>
   <li class="ds-li"><kbd class="ds-kbd">id</kbd> attribute: a unique, automatically generated id</li>
   <li class="ds-li"><kbd class="ds-kbd">aria-hidden</kbd> attribute: set to true</li>
@@ -23,12 +27,12 @@
   <li class="ds-li">(CSS)<kbd class="ds-kbd">class</kbd>: flight-icon, flight-icon-NAME, flight-icon-display-inline</li>
   <li class="ds-li">CSS display: set to <kbd class="ds-kbd">display:inline-block</kbd></li>
   <li class="ds-li"><kbd class="ds-kbd">data-test-icon</kbd> attribute: for the author's testing convenience</li>
-</ul>
+</ol>
 </p>
 
-<p class="ds-p">This makes the base, required invocation quite terse- <kbd class="ds-kbd">@name</kbd> is the only property that requires specification.
 
-<br>So this invocation:
+<p >This makes the base, required invocation quite terse- <kbd class="ds-kbd">@name</kbd> is the only property that requires specification.
+So this invocation:
 <pre class="ds-pre"><code class="ds-code">&lt;FlightIcon @name="alert-circle" /></code></pre>
 Renders to this:
 <pre class="ds-pre"><code class="ds-code">
@@ -43,67 +47,74 @@ Renders to this:
   viewBox="0 0 16 16"
   xmlns="http://www.w3.org/2000/svg">
     &lt;use href="/@hashicorp/ember-flight-icons/icons/sprite.svg#alert-circle-16">&lt;/use>
-&lt;/svg>
-</code>
-</pre>
+&lt;/svg></code></pre>
 </p>
-<p class="ds-p">The <kbd class="ds-kbd">`&lt;use>`</kbd> element will then render the correct svg to the shadow dom.</p>
+<p >The <kbd class="ds-kbd">`&lt;use>`</kbd> element will then render the correct svg to the shadow dom.</p>
+</div>
 
-<h3 class="ds-h3" id="customizable"><a href="#customizable">&sect;</a> Customizable properties</h3>
-<p class="ds-p">The following properties are customizable:
+<div class="mt-8 prose prose-lg text-gray-800 pb-6">
+<h3 class="ds-h3" id="customizable"><a href="#customizable" class="ds-a" rel="external">&sect;</a> Customizable properties</h3>
+<p >The following properties are customizable:
   <ul class="ds-ul">
     <li class="ds-li">fill</li>
     <li class="ds-li">height/width/viewBox (at this time, only 16 (default) and 24 are supported)</li>
     <li class="ds-li">additional CSS classes</li>
   </ul>
 </p>
+</div>
+<div class="mt-8 prose prose-lg text-gray-800 pb-6">
 <h4 class="ds-h4">Examples</h4>
-<p class="ds-p" id="example-fill">
-  <strong><a href="#example-fill">&sect;</a>Fill:</strong> To customize the fill attribute, set the <kbd class="ds-kbd">`@color`</kbd> value (multiple supported ways):
+<p  id="example-fill">
+  <strong><a href="#example-fill" class="ds-a" rel="external">&sect;</a>Fill:</strong> To customize the fill attribute, set the <kbd class="ds-kbd">`@color`</kbd> value (multiple supported ways):
   <pre class="ds-pre"><code class="ds-code">&lt;!-- Preferred method to ensure consistency: using a :root variable -->
 
 &lt;FlightIcon @name="zap" @color="var(--brand)" /></code></pre>
 <pre class="ds-pre"><code class="ds-code">&lt;FlightIcon @name="zap" @color="rebeccapurple" /></code></pre>
 <pre class="ds-pre"><code class="ds-code">&lt;FlightIcon @name="zap" @color="rgb(46, 113, 229)" /></code></pre>
 </p>
-<p class="ds-p" id="example-size">
-  <strong><a href="#example-size">&sect;</a>Size:</strong> To use the 24x24 (px) icon size, set the <kbd class="ds-kbd">`@size`</kbd> value:
+<p  id="example-size">
+  <strong><a href="#example-size" class="ds-a" rel="external">&sect;</a>Size:</strong> To use the 24x24 (px) icon size, set the <kbd class="ds-kbd">`@size`</kbd> value:
   <pre class="ds-pre"><code class="ds-code">&lt;FlightIcon @name="zap" @size="24" /></code></pre>
 </p>
-<p class="ds-p" id="example-styles">
-  <strong><a href="#example-styles">&sect;</a>CSS Classes:</strong> To append additional classes to the component, add <kbd class="ds-kbd">`class`</kbd> with value(s):
+<p  id="example-styles">
+  <strong><a href="#example-styles" class="ds-a" rel="external">&sect;</a>CSS Classes:</strong> To append additional classes to the component, add <kbd class="ds-kbd">`class`</kbd> with value(s):
   <pre class="ds-pre"><code class="ds-code">&lt;FlightIcon @name="triangle-fill" class="ds-rotate-90" /></code></pre>
 </p>
-<p class="ds-p" id="example-display">
-  <strong><a href="#example-display">&sect;</a>CSS Display:</strong> To change the default display of <i>inline-block</i> to <i>block</i>, set <kbd class="ds-kbd">`@isInlineBlock`</kbd> to false:
+<p  id="example-display">
+  <strong><a href="#example-display" class="ds-a" rel="external">&sect;</a>CSS Display:</strong> To change the default display of <i>inline-block</i> to <i>block</i>, set <kbd class="ds-kbd">`@isInlineBlock`</kbd> to false:
   <pre class="ds-pre"><code class="ds-code">&lt;FlightIcon @name="triangle-fill" @isInlineBlock=&lbrace;&lbrace;false&rbrace;&rbrace; /></code></pre>
 </p>
-<hr/>
+</div>
 
-<h2 class="ds-h2" id="use-other"><a href="#use-other">&sect;</a> Using the flight-icon package in other ways</h2>
-<p class="ds-h2">
+<div class="mt-8 prose prose-lg text-gray-800 pb-6">
+
+<h2 class="ds-h2" id="use-other"><a href="#use-other" class="ds-a" rel="external">&sect;</a> Using the flight-icon package in other ways</h2>
+<p>
   It is also possible to install the flight-icon package itself. 
   To do so, run:
 <pre class="ds-pre"><code class="ds-code">yarn install @hashicorp/flight-icons</code></pre>
 This will allow icons to be imported and used as desired. Note that the icons are namespaced:
 <pre class="ds-pre"><code class="ds-code">@hashicorp/flight-icons/icons/arrow-right-16.svg</code></pre>
 </p>
-<p class="ds-p">
+<p >
   Authors should also follow the following guidelines:
   <ul class="ds-ul">
     <li class="ds-li">The icons are sized as 16x16(px) and 24x24(px) and should not be used at different sizes without a design consult.</li>
     <li class="ds-li">The icons do not have a unique id generated; authors should take precautions to avoid <a href="https://www.w3.org/TR/WCAG20-TECHS/F77.html" rel="external">related accessibility conformance failures</a>.</li>
   </ul>
 </p>
+</div>
+<div class="mt-8 prose prose-lg text-gray-800 pb-6">
+<h2 class="ds-h2" id="accessibility"><a href="#accessibility" class="ds-a" rel="external">&sect;</a> Accessibility</h2>
 
-<h2 class="ds-h2" id="accessibility"><a href="#accessibility">&sect;</a> Accessibility</h2>
-
-<p class="ds-p">
+<p >
 Accessibility (a11y) support for SVGs is inconsistent across browsers and assistive technology. Currently, best practice is to set the <kbd class="ds-kbd">`aria-hidden`</kbd> attribute to `false` on the SVG itself.
 This means that the icon (both the singular icon and the icon component) will need to be used <em class="ds-em">in context</em>.
 The icons themselves are for presentation purposes only and should never be used on their own.
 </p>
+</div>
 
+<div class="mt-8 prose prose-lg text-gray-800 pb-6">
 <h3 class="ds-h3">Example</h3>
 
 <pre class="ds-pre"><code class="ds-code">&lt;button aria-label="Check Activity">
@@ -111,3 +122,4 @@ The icons themselves are for presentation purposes only and should never be used
 &lt;/button></code></pre>
 
 <pre class="ds-pre"><code class="ds-code">&lt;h2>Activity Report &lt;FlightIcon @name="activity" />&lt;/h2></code></pre>
+</div>


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR formats the engineering docs with the same layout classes as the design docs page.


## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/4587451/133107715-eff101cc-daa6-4201-9d38-f9fe854e8c7d.png)

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
