### PR TITLE
enhancement: added footer info to docs site

### DIFF
--- a/ember-flight-icons/tests/dummy/app/components/ds-footer.hbs
+++ b/ember-flight-icons/tests/dummy/app/components/ds-footer.hbs
@@ -6,9 +6,9 @@
     </div>
     <div class="flex justify-evenly w-full md:w-1/2 md:h-full">
       <p><b>Contact Us</b></p>
-      <p>
+      <a href="https://hashicorp.slack.com/archives/C7KTUHNUS" class="ds-a">
         #team-design-systems (Slack)
-      </p>
+      </a>
 
       <a href="mailto:design-systems@hashicorp.com" class="ds-a">
         design-systems@hashicorp.com

--- a/ember-flight-icons/tests/dummy/app/components/ds-footer.hbs
+++ b/ember-flight-icons/tests/dummy/app/components/ds-footer.hbs
@@ -1,5 +1,17 @@
 <footer class="ds-footer">
-  <p class="ds-p">
-    <small>&copy; 2021 HashiCorp. All rights reserved.</small>
-  </p>
+    <div class="flex sm:justify-center md:justify-start w-full md:w-1/2 md:h-full">
+      <p>
+        &copy; 2021 HashiCorp, Inc. All rights reserved.
+      </p>
+    </div>
+    <div class="flex justify-evenly w-full md:w-1/2 md:h-full">
+      <p><b>Contact Us</b></p>
+      <p>
+        #team-design-systems (Slack)
+      </p>
+
+      <a href="mailto:design-systems@hashicorp.com" class="ds-a">
+        design-systems@hashicorp.com
+      </a>
+    </div>
 </footer>

--- a/ember-flight-icons/tests/dummy/app/styles/app.css
+++ b/ember-flight-icons/tests/dummy/app/styles/app.css
@@ -236,3 +236,9 @@ div.code-toolbar > .toolbar > .toolbar-item > a, div.code-toolbar > .toolbar > .
 .prose-lg pre.language-markup {
   @apply mt-0;
 }
+
+
+/* some editing utilities */
+.ds-b-red {
+  border: 1px solid red;
+}

--- a/ember-flight-icons/tests/dummy/app/styles/footer.css
+++ b/ember-flight-icons/tests/dummy/app/styles/footer.css
@@ -1,13 +1,14 @@
 footer.ds-footer {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: flex-center;
-  min-height: 50px;
-}
-
-footer.ds-footer p.ds-p {
-  align-items: stretch;
-  display: flex;
-  justify-content: center;
-  padding: 0.5em 1em;
+  @apply border-gray-200 
+  border-t-2 
+  flex
+  flex-wrap
+  justify-between
+  px-8
+  py-8
+  md:m-auto 
+  md:max-w-full 
+  md:mt-16
+  md:py-16
+  md:px-16;
 }


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR adds a footer to the documentation site


## :camera_flash: Screenshots

![image](https://user-images.githubusercontent.com/4587451/133310448-87dc4b91-3c7f-4a9f-8432-e6ca64a55f90.png)

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
