### PR TITLE
Bugfix: resolves issue where the data-test-icon attribute had no value

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -2,7 +2,7 @@
   class="flight-icon flight-icon-{{@name}} {{if this.display "flight-icon-display-inline"}}"
   ...attributes
   aria-hidden="true"
-  data-test-icon
+  data-test-icon={{this.iconId}}
   fill="{{this.color}}"
   id={{this.iconId}}
   width="{{this.size}}"

--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -2,7 +2,7 @@
   class="flight-icon flight-icon-{{@name}} {{if this.display "flight-icon-display-inline"}}"
   ...attributes
   aria-hidden="true"
-  data-test-icon={{this.iconId}}
+  data-test-icon={{@name}}
   fill="{{this.color}}"
   id={{this.iconId}}
   width="{{this.size}}"

--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -93,6 +93,7 @@
     "ember-source": "~3.26.1",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.5.1",
+    "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.0.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.27.0",

--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -58,7 +58,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^5.7.1"
+    "ember-cli-htmlbars": "^5.7.1",
+    "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -93,7 +94,6 @@
     "ember-source": "~3.26.1",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.5.1",
-    "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.0.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.27.0",

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -15,6 +15,8 @@
   <p>To install, run
   <CodeBlock @code="yarn add @hashicorp/ember-flight-icons" @language="bash" />
   </p>
+  <p>Note: <kbd class="ds-kbd">ember-test-selectors</kbd> is a dependency added for the author's convenience. 
+  <a href="https://github.com/simplabs/ember-test-selectors" class="ds-a">This Ember Addon</a> strips out all <kbd class="ds-kbd">data-test-*</kbd> attributes for production builds.</p>
 </div>
 
 <div class="mt-8 prose prose-lg text-gray-800 pb-6">
@@ -42,7 +44,7 @@
 @code="&lt;svg 
  aria-hidden=&quot;true&quot; 
  class=&quot;flight-icon icon-alert-circle display-inline&quot; 
- data-test-icon=&quot;icon-ember115&quot;
+ data-test-icon=&quot;alert-circle&quot;
  fill=&quot;currentColor&quot; 
  id=&quot;icon-ember115&quot;
  width=&quot;16&quot;

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -27,7 +27,7 @@
     <li class="ds-li"><kbd class="ds-kbd">height</kbd> and <kbd class="ds-kbd">width</kbd>: default size of 16x16 (px)</li>
     <li class="ds-li">(CSS)<kbd class="ds-kbd">class</kbd>: flight-icon, flight-icon-NAME, flight-icon-display-inline</li>
     <li class="ds-li">CSS display: set to <kbd class="ds-kbd">display:inline-block</kbd></li>
-    <li class="ds-li"><kbd class="ds-kbd">data-test-icon</kbd> attribute: for the author's testing convenience</li>
+    <li class="ds-li"><kbd class="ds-kbd">data-test-icon</kbd> attribute: for the author's testing convenience; set to the value of the auto-generated (unique) id.</li>
   </ol>
   </p>
 
@@ -37,12 +37,12 @@
   </p>
 
   <p>
-  Renders to this:
+  Renders to this (where the ID will be unique each time):
 <CodeBlock @language="markup" id="component-invocation-base-render"
 @code="&lt;svg 
  aria-hidden=&quot;true&quot; 
  class=&quot;flight-icon icon-alert-circle display-inline&quot; 
- data-test-icon
+ data-test-icon=&quot;icon-ember115&quot;
  fill=&quot;currentColor&quot; 
  id=&quot;icon-ember115&quot;
  width=&quot;16&quot;

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -27,7 +27,7 @@
     <li class="ds-li"><kbd class="ds-kbd">height</kbd> and <kbd class="ds-kbd">width</kbd>: default size of 16x16 (px)</li>
     <li class="ds-li">(CSS)<kbd class="ds-kbd">class</kbd>: flight-icon, flight-icon-NAME, flight-icon-display-inline</li>
     <li class="ds-li">CSS display: set to <kbd class="ds-kbd">display:inline-block</kbd></li>
-    <li class="ds-li"><kbd class="ds-kbd">data-test-icon</kbd> attribute: for the author's testing convenience; set to the value of the auto-generated (unique) id.</li>
+    <li class="ds-li"><kbd class="ds-kbd">data-test-icon</kbd> attribute: for the author's testing convenience; set to the value of the <kbd class="ds-kbd">@name</kbd> property.</li>
   </ol>
   </p>
 

--- a/ember-flight-icons/yarn.lock
+++ b/ember-flight-icons/yarn.lock
@@ -5493,7 +5493,7 @@ ember-cli-babel@^6.0.0-beta.4:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.20.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.20.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -6146,6 +6146,15 @@ ember-template-recast@^5.0.3:
     slash "^3.0.0"
     tmp "^0.2.1"
     workerpool "^6.1.4"
+
+ember-test-selectors@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-6.0.0.tgz#ba9bb19550d9dec6e4037d86d2b13c2cfd329341"
+  integrity sha512-PgYcI9PeNvtKaF0QncxfbS68olMYM1idwuI8v/WxsjOGqUx5bmsu6V17vy/d9hX4mwmjgsBhEghrVasGSuaIgw==
+  dependencies:
+    calculate-cache-key-for-tree "^2.0.0"
+    ember-cli-babel "^7.26.4"
+    ember-cli-version-checker "^5.1.2"
 
 ember-truth-helpers@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR resolves the issue where the `data-test-icon` attribute had no value. It now explicitly sets the value to `{{@name}}`.

The docs have also been updated to reflect this change. 

The `ember-test-selectors` ([an Ember testing addon](https://github.com/simplabs/ember-test-selectors)) has been added to help ensure that `data-test-*` attributes are stripped properly from production builds. 

Resolves #31 

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
