### PR TITLE
Add back test, with more specificity

### DIFF
--- a/ember-flight-icons/tests/acceptance/index-test.js
+++ b/ember-flight-icons/tests/acceptance/index-test.js
@@ -9,9 +9,11 @@ module('Acceptance | icon index', function (hooks) {
 
   test('visiting / renders a list of icons', async function (assert) {
     await visit('/');
-    // added this because the icons are not rendering as quickly
-    await waitFor('.flight-icon', { timeout: 1000 });
+
+    // added timeout because the icons are not rendering as quickly
+    await waitFor('.ds-icon-frame > .flight-icon', { timeout: 1000 });
+    assert.dom('[data-test-target="icon-grid"] [data-test-icon]').exists();
+
     await percySnapshot('Icons page');
-    assert.ok(true);
   });
 });


### PR DESCRIPTION
## :pushpin: Summary

Add back test, with more specificity 

It's possible that in CI, the test was waiting for the icons at the top linking to the docs in the rectangular grid, not the full set of icons below, as can't repro locally.

Note: Update this PR if https://github.com/hashicorp/flight/pull/219 lands, maybe with the first data-test-icon name in .ds-icon-frame

## :link: External Links

Resolves: https://github.com/hashicorp/flight/issues/207
