### PR TITLE
Update npm docs

### DIFF
--- a/ember-flight-icons/CONTRIBUTING.md
+++ b/ember-flight-icons/CONTRIBUTING.md
@@ -24,13 +24,13 @@
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
 
-## Releasing a new version of the package
+## 🚧 [WIP] Releasing a new npm version of the package
 
 ```bash
 cd ember-flight-icons
 ```
 
-Bump the version number for the `ember-flight/package.json`.
+Bump the version number, per SemVer, for the `ember-flight/package.json`.
 
 After the change is merged to `main`, from the `ember-flight-icons/` directory, run:
 

--- a/flight-icons/CONTRIBUTING.md
+++ b/flight-icons/CONTRIBUTING.md
@@ -40,11 +40,8 @@ This action will:
 * Prepare a bundle with SVGs embedded in CSS/SCSS as data:image
 * Update the SVG sprite and catalog.json files in the Ember addon folder
 
-### Release
-
-[TODO]
-
 ### Code check
+
 You can also do some important sanity checks to the code via the commands:
 
 ```bash
@@ -108,15 +105,13 @@ yarn build
 [TODO]
 ```
 
-## Release
-
-_NOTICE: with the recent changes to the project folder structure and sync/build scripts, these instructions are outdated._
+## 🚧 [WIP] Releasing a new npm version of the package
 
 ```bash
 cd flight-icons
 ```
 
-- Bump the version number for the `flight-icons/package.json`.
+- Bump the version number, per SemVer, for the `flight-icons/package.json`.
 
 After the change is merged to `main`, from the `flight-icons/` directory, run:
 
@@ -126,7 +121,7 @@ npm publish
 
 You will need 2FA on your npm account to publish.
 
-## GitHub action
+## 🚧 [WIP] GitHub action
 
 Run the GitHub action `flight_compile` to execute the `sync → build → release` process.
 


### PR DESCRIPTION
## :pushpin: Summary

This is a slight update to the docs as-is. 

//

I'm still looking at release-it (https://github.com/hashicorp/flight/issues/115), is my first time using it. 

I see some benefit to automating it... but we have to keep in mind that one package could be bumped differently than the other. There are instances where we will only bump `@hashicorp/ember-flight-icons` and not `@hashicorp/flight-icons`. So... I would suggest we keep the releases atomic, which I think relates to the overarching goal of Cristiano's vision (flight-icons-svg could be consumed by ember-flight-icons, a potential future react-flight-icons etc.)

The idea behind the ticket is to get release-it to release both ember-flight-icons  package.json and flight-icons package.json within the "monorepo" we have right now, perhaps with https://github.com/rwjblue/release-it-yarn-workspaces which Cristiano shared.

I like Melanie's suggestion of using release-it and release-it-lerna-changelog https://github.com/hashicorp/flight/issues/115#issuecomment-906539536, which links to https://github.com/ember-a11y/ember-a11y-refocus/blob/master/RELEASE.md ... but keep in mind this isn't a huge automated improvement to what we have as-is in this PR. 

I would argue that we _do_ want to discuss SemVer as a team in a PR, to make sure we agree on what's patch/minor/major, especially if we have to maintain multiple versions of a style-guide. Which is why I kind of prefer having that be a part of code review. 

Can continue to work on release-it schemes tomorrow though, even if it's adding it to both packages as an incremental step forward. 