### PR TITLE
Export script (Node version) - Releasing (PR - Part #3: Documentation)

### DIFF
--- a/ember-flight-icons/CONTRIBUTING.md
+++ b/ember-flight-icons/CONTRIBUTING.md
@@ -24,21 +24,27 @@
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
 
-## 🚧 [WIP] Releasing a new npm version of the package
+## Releasing a new npm version of the package
+
+To trigger a release, we have defined a special set of NPM scripts commands in the `package.json` file. Use the following command in your CLI:
+
 
 ```bash
-cd ember-flight-icons
+yarn release
 ```
 
-Bump the version number, per SemVer, for the `ember-flight/package.json`.
+_**IMPORTANT**: if you need to do some tests, use a **local** package registry (see [CONTRIBUTING](../flight-icons/CONTRIBUTING.md) in the `flight-icon`), don't test directly in production!_
 
-After the change is merged to `main`, from the `ember-flight-icons/` directory, run:
+This action will:
 
-```bash
-npm publish
-```
+* ask which _semver_ version you want to to use (the `bump` command is interactive, you can move up and down with the keyboard, choose one option, and then hit "enter").
+* update the version in the `package.json` file
+* automatically publish the new version of the `ember-flight-icons` package on the [NPM registry](https://www.npmjs.com/)
 
-You will need 2FA on your npm account to publish.
+_Notice: you will need a company-approved account on npm (with 2FA) to publish._
+
+At this point check on [www.npmjs.com/package/@hashicorp/ember-flight-icons](https://www.npmjs.com/package/@hashicorp/ember-flight-icons) that the package has been successfully published (under the "versions" tab) and you're good. Well done you just published your new package! 🎉
+
 
 ## Testing local changes to the addon
 

--- a/ember-flight-icons/CONTRIBUTING.md
+++ b/ember-flight-icons/CONTRIBUTING.md
@@ -39,7 +39,7 @@ This action will:
 
 * ask which _semver_ version you want to to use (the `bump` command is interactive, you can move up and down with the keyboard, choose one option, and then hit "enter").
 * update the version in the `package.json` file
-* automatically publish the new version of the `ember-flight-icons` package on the [NPM registry](https://www.npmjs.com/)
+* automatically publish the new version of the `@hashicorp/ember-flight-icons` package on the [NPM registry](https://www.npmjs.com/)
 
 _Notice: you will need a company-approved account on npm (with 2FA) to publish._
 

--- a/ember-flight-icons/CONTRIBUTING.md
+++ b/ember-flight-icons/CONTRIBUTING.md
@@ -26,25 +26,27 @@ For more information on using ember-cli, visit [https://ember-cli.com/](https://
 
 ## Releasing a new npm version of the package
 
-To trigger a release, we have defined a special set of NPM scripts commands in the `package.json` file. Use the following command in your CLI:
+The release process is in two steps.
 
+In the first step you need to do a "bump" of the version of the package:
+
+```bash
+yarn bump
+```
+
+This will increase the version number in the `package.json` file. Once you have submitted the pull request for this change, and `main` has been updated, you can move to the next step.
+
+In the second step you publish the package on the npm registry
 
 ```bash
 yarn release
 ```
 
-_**IMPORTANT**: if you need to do some tests, use a **local** package registry (see [CONTRIBUTING](../flight-icons/CONTRIBUTING.md) in the `flight-icon`), don't test directly in production!_
-
-This action will:
-
-* ask which _semver_ version you want to to use (the `bump` command is interactive, you can move up and down with the keyboard, choose one option, and then hit "enter").
-* update the version in the `package.json` file
-* automatically publish the new version of the `@hashicorp/ember-flight-icons` package on the [NPM registry](https://www.npmjs.com/)
-
 _Notice: you will need a company-approved account on npm (with 2FA) to publish._
 
-At this point check on [www.npmjs.com/package/@hashicorp/ember-flight-icons](https://www.npmjs.com/package/@hashicorp/ember-flight-icons) that the package has been successfully published (under the "versions" tab) and you're good. Well done you just published your new package! 🎉
+At this point check on [www.npmjs.com/package/@hashicorp/flight-icons](https://www.npmjs.com/package/@hashicorp/flight-icons) that the package has been successfully published (under the "versions" tab) and you're good. Well done, you just published your new package! 🎉
 
+_**IMPORTANT**: if you need to do some tests, use a **local** package registry (see [CONTRIBUTING](../flight-icons/CONTRIBUTING.md) in the `flight-icon`), don't test directly in production!_
 
 ## Testing local changes to the addon
 

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -15,7 +15,7 @@
   <p>To install, run
   <CodeBlock @code="yarn add @hashicorp/ember-flight-icons" @language="bash" />
   </p>
-  <p>Note: <kbd class="ds-kbd">ember-test-selectors</kbd> is a dependency added for the author's convenience. 
+  <p>Note: <kbd class="ds-kbd">ember-test-selectors</kbd> is a dependency added for the author's convenience.
   <a href="https://github.com/simplabs/ember-test-selectors" class="ds-a">This Ember Addon</a> strips out all <kbd class="ds-kbd">data-test-*</kbd> attributes for production builds.</p>
 </div>
 
@@ -41,11 +41,11 @@
   <p>
   Renders to this (where the ID will be unique each time):
 <CodeBlock @language="markup" id="component-invocation-base-render"
-@code="&lt;svg 
- aria-hidden=&quot;true&quot; 
- class=&quot;flight-icon icon-alert-circle display-inline&quot; 
+@code="&lt;svg
+ aria-hidden=&quot;true&quot;
+ class=&quot;flight-icon icon-alert-circle display-inline&quot;
  data-test-icon=&quot;alert-circle&quot;
- fill=&quot;currentColor&quot; 
+ fill=&quot;currentColor&quot;
  id=&quot;icon-ember115&quot;
  width=&quot;16&quot;
  height=&quot;16&quot;
@@ -72,7 +72,7 @@
 <div class="mt-8 prose prose-lg text-gray-800 pb-6">
   <h4 class="ds-h4">Examples</h4>
   <p id="example-fill">
-    <strong><a href="#example-fill" class="ds-a" rel="external">&sect;</a>Fill:</strong> To customize the fill attribute, set the <kbd class="ds-kbd">@color</kbd> value (multiple supported ways). 
+    <strong><a href="#example-fill" class="ds-a" rel="external">&sect;</a>Fill:</strong> To customize the fill attribute, set the <kbd class="ds-kbd">@color</kbd> value (multiple supported ways).
     The recommended approach to ensure consistency is to use one of the pre-defined variables:
     <CodeBlock @language="markup" @code="&lt;FlightIcon @name=&quot;zap&quot; @color=&quot;var(--brand)&quot; />" />
   </p>
@@ -99,12 +99,12 @@
 <div class="mt-8 prose prose-lg text-gray-800 pb-6">
   <h2 class="ds-h2" id="use-other"><a href="#use-other" class="ds-a" rel="external">&sect;</a> Using the flight-icon package in other ways</h2>
   <p>
-    It is also possible to install the flight-icon package itself. 
+    It is also possible to install the flight-icon package itself.
     To do so, run:
   <CodeBlock @language="bash" @code="yarn install @hashicorp/flight-icons" />
   This will allow icons to be imported and used as desired. Note that the icons are namespaced:
   {{!-- template-lint-disable 'no-potential-path-strings' --}}
-  <CodeBlock @language="bash" @code="@hashicorp/flight-icons/icons/arrow-right-16.svg" />
+  <CodeBlock @language="bash" @code="@hashicorp/flight-icons/svg/arrow-right-16.svg" />
    {{!-- template-lint-enable 'no-potential-path-strings' --}}
   </p>
   <p>

--- a/flight-icons/CONTRIBUTING.md
+++ b/flight-icons/CONTRIBUTING.md
@@ -84,6 +84,8 @@ This action will:
 * Update the existing files in the Ember addon folder:
     * Process the optimized SVG, generate a SVG sprite, and overwrite the existing sprite
     * Overwrite the catalog.json with the new one
+    
+_**Notice**: as mentioned above, this step not only updates the content of the `flight-icons` folder, but also the content of the `ember-flight-icons`. You will see these changes reflected in your git diff status._
 
 ## Release
 
@@ -94,20 +96,20 @@ The release step is executed using a set of NPM scripts defined in the `package.
 yarn release
 ```
 
+_**IMPORTANT**: if you need to do some tests, use a **local** package registry (see below), don't test directly in production!_
+
+
 This action will:
 
-* ask (interactively*) the user which _semver_ version they want to to use
-	* the `bump` command will interactively ask you which semver version you want to use: you can move up and down with the keyboard, choose one option, and then hit "enter".
-* update the `package.json` file with that version
-* release the bundle on the [NPM registry](https://www.npmjs.com/)
-
-The script will automatically bump the version in the `package.json` file, and publish the new version of the `flight-icons` package.
+* ask which _semver_ version you want to to use (the `bump` command is interactive, you can move up and down with the keyboard, choose one option, and then hit "enter").
+* update the version in the `package.json` file
+* automatically publish the new version of the `flight-icons` package on the [NPM registry](https://www.npmjs.com/)
 
 _Notice: you will need a company-approved account on npm (with 2FA) to publish._
 
 At this point check on [www.npmjs.com/package/@hashicorp/flight-icons](https://www.npmjs.com/package/@hashicorp/flight-icons) that the package has been successfully published (under the "versions" tab) and you're good. Well done you just published your new package! 🎉
 
-**IMPORTANT**: if you need to do some tests, use a **local** package registry, not production! (see below)
+🚨 **DON'T FORGET**: if you're releasing a new version of the `flight-icons`, this means that during the `build` step the SVG sprite and the `catalog.json` file in the `ember-flight-icons` have also been updated, which means you have to do a release also of that package.
 
 
 ## Local development

--- a/flight-icons/CONTRIBUTING.md
+++ b/flight-icons/CONTRIBUTING.md
@@ -103,13 +103,13 @@ This action will:
 
 * ask which _semver_ version you want to to use (the `bump` command is interactive, you can move up and down with the keyboard, choose one option, and then hit "enter").
 * update the version in the `package.json` file
-* automatically publish the new version of the `flight-icons` package on the [NPM registry](https://www.npmjs.com/)
+* automatically publish the new version of the `@hashicorp/flight-icons` package on the [NPM registry](https://www.npmjs.com/)
 
 _Notice: you will need a company-approved account on npm (with 2FA) to publish._
 
 At this point check on [www.npmjs.com/package/@hashicorp/flight-icons](https://www.npmjs.com/package/@hashicorp/flight-icons) that the package has been successfully published (under the "versions" tab) and you're good. Well done you just published your new package! 🎉
 
-🚨 **DON'T FORGET**: if you're releasing a new version of the `flight-icons`, this means that during the `build` step the SVG sprite and the `catalog.json` file in the `ember-flight-icons` have also been updated, which means you have to do a release also of that package.
+🚨 **DON'T FORGET**: if you're releasing a new version of `@hashicorp/flight-icons`, this means that during the `build` step the SVG sprite and the `catalog.json` file in the `ember-flight-icons/` have also been updated, which means you have to do a release also of that package.
 
 
 ## Local development

--- a/flight-icons/CONTRIBUTING.md
+++ b/flight-icons/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Whenever there is an update to the Flight Icons library in Figma (eg. a new icon
 
 _Remember: once released a package on the public registry, you can't revert the changes: the only solution is to deprecate the package (this will hide it from the public, but remains there)._
 
-The update process for the icons should happen in a dedicated branch, associated with the GitHub task/issue. Once you have run the `yarn sync` and `yarn build` (see the instructions below), check the diff in your git client, and once you're OK with them commit the changes to the branch, push and then ask for a pull request.
+The update process for the icons should happen in a dedicated branch, associated with the GitHub task/issue. Once you have run the `yarn sync` and `yarn build` (see the instructions below), check the diff in your git client, and once you're OK with them commit & push the changes to the branch, and then open a pull request in GitHub.
 
 Once this request has been approved and the branch merged in `main`, you can publish the package (using directly the `main` branch, no need to create a new PR for this) using the `release` command (see the instructions below).
 

--- a/flight-icons/CONTRIBUTING.md
+++ b/flight-icons/CONTRIBUTING.md
@@ -14,8 +14,30 @@ _Remember: once released a package on the public registry, you can't revert the 
 
 The update process for the icons should happen in a dedicated branch, associated with the GitHub task/issue. Once you have run the `yarn sync` and `yarn build` (see the instructions below), check the diff in your git client, and once you're OK with them commit & push the changes to the branch, and then open a pull request in GitHub.
 
-Once this request has been approved and the branch merged in `main`, you can publish the package (using directly the `main` branch, no need to create a new PR for this) using the `release` command (see the instructions below).
+Once this request has been approved and the branch merged in `main`, you bump the _semver_ version via `yarn bump` (see the instructions below), open a new pull request, and once this is approved and merged to master, you can finally and safely release the package to the registry via `yarn release` (see the instructions below).
 
+Please follow the steps in the sections below, which describe with more details the process.
+
+If you need a TLDR; here's the sequence of steps you have to follow:
+
+- `cd /[your-local-project-path]/flight-icons`
+- create custom branch from `main`
+- `yarn sync`
+- `yarn build`
+- commit, push, open PR, wait for approval
+- pull from main
+- `cd /[your-local-project-path]/flight-icons`
+- create new custom branch from `main`
+- `yarn bump`
+- choose _semver_ version
+- commit, push, open PR, wait for approval
+- pull from main
+- `cd /[your-local-project-path]/flight-icons`
+- `yarn release`
+- `cd /[your-local-project-path]/ember-flight-icons`
+- `yarn release`
+- check [www.npmjs.com/package/@hashicorp/flight-icons](https://www.npmjs.com/package/@hashicorp/flight-icons)
+- profit! 🎉
 
 ## Initial setup
 
@@ -57,7 +79,10 @@ Once you've done the initial setup, there are three distinct steps in the proces
 
 ## Sync
 
-The synchronization step is executed by the `/scripts/sync.ts` file. To run this script launch the following commands in your CLI (while in the `flight-icons` folder):
+The "sync" step exports the assets from Figma and saves them in the project.
+You can find the code that relates to this step in the file `/scripts/sync.ts`.
+
+To run this script launch the following commands in your CLI (while in the `flight-icons` folder):
 
 ```bash
 yarn sync
@@ -71,7 +96,10 @@ This action will:
 
 ## Build
 
-The build step is executed by the `/scripts/build.ts` file. To run this script use the following command in your CLI (while in the `flight-icons` folder):
+The "build" step takes the assets exported from Figma, optimize and process them, and saves the final SVG files in the bundles that will be published as npm packages.
+You can find the code that relates to this step in the file `/scripts/build.ts`.
+
+To run this script use the following command in your CLI (while in the `flight-icons` folder):
 
 ```bash
 yarn build
@@ -84,12 +112,33 @@ This action will:
 * Update the existing files in the Ember addon folder:
     * Process the optimized SVG, generate a SVG sprite, and overwrite the existing sprite
     * Overwrite the catalog.json with the new one
-    
-_**Notice**: as mentioned above, this step not only updates the content of the `flight-icons` folder, but also the content of the `ember-flight-icons`. You will see these changes reflected in your git diff status._
+
+_**Notice**: this step not only updates the content of the `flight-icons` folder, but also the content of the `ember-flight-icons`. You will see these changes reflected in your git diff status._
+
+When this step is done, and you have committed and pushed all the changes, submit a pull request in GitHub. Once approved and merged to the `main` branch, you can move to the next step.
+
+## Bump
+
+The "bump" step increases the version number in the `package.json` file.
+
+Use the following command in your CLI (while in the `flight-icons` folder):
+
+```bash
+yarn bump
+```
+
+This action will:
+
+* ask you which _semver_ version you want to to use (the `bump` command is interactive, you can move up and down with the keyboard, choose one option, and then hit "enter").
+* update the version in the `package.json` file
+
+When this step is done, commit and push the changes to the `package.json` file, and submit a new pull request in GitHub. Once also this one has been approved and merged to the `main` branch, you can finally move to the last step, the actual release.
 
 ## Release
 
-The release step is executed using a set of NPM scripts defined in the `package.json` file. Use the following command in your CLI (while in the `flight-icons` folder):
+The "release" step publishes the package on the npm registry (using the version declared in the `package.json` file).
+
+Use the following command in your CLI (while in the `flight-icons` folder):
 
 
 ```bash
@@ -98,19 +147,16 @@ yarn release
 
 _**IMPORTANT**: if you need to do some tests, use a **local** package registry (see below), don't test directly in production!_
 
-
 This action will:
 
 * ask which _semver_ version you want to to use (the `bump` command is interactive, you can move up and down with the keyboard, choose one option, and then hit "enter").
 * update the version in the `package.json` file
 * automatically publish the new version of the `@hashicorp/flight-icons` package on the [NPM registry](https://www.npmjs.com/)
+  * _Notice: you will need a company-approved account on npm (with 2FA) to publish._
 
-_Notice: you will need a company-approved account on npm (with 2FA) to publish._
+At this point check on [www.npmjs.com/package/@hashicorp/flight-icons](https://www.npmjs.com/package/@hashicorp/flight-icons) that the package has been successfully published (under the "versions" tab) and you're good. Well done, you just published your new package! 🎉
 
-At this point check on [www.npmjs.com/package/@hashicorp/flight-icons](https://www.npmjs.com/package/@hashicorp/flight-icons) that the package has been successfully published (under the "versions" tab) and you're good. Well done you just published your new package! 🎉
-
-🚨 **DON'T FORGET**: if you're releasing a new version of `@hashicorp/flight-icons`, this means that during the `build` step the SVG sprite and the `catalog.json` file in the `ember-flight-icons/` have also been updated, which means you have to do a release also of that package.
-
+🚨 **DON'T FORGET**: if you're releasing a new version of `@hashicorp/flight-icons`, this means that during the `build` step the SVG sprite and the `catalog.json` file in the `ember-flight-icons/` have also been updated, which means you have to release also that package.
 
 ## Local development
 
@@ -152,6 +198,6 @@ Once you've done testing, you can remove verdaccio via `npm uninstall -g verdacc
 
 ## 🚧 [WIP] GitHub action
 
-Run the GitHub action `flight_compile` to execute the `sync → build → release` process.
+Run the GitHub action `flight_compile` to execute the `sync → build` process.
 
 All the updated assets and the generated bundles will be automatically committed to this repo, and the packages released to NPM.

--- a/flight-icons/CONTRIBUTING.md
+++ b/flight-icons/CONTRIBUTING.md
@@ -2,73 +2,23 @@
 
 A set of Node.js scripts developed to create a single pipeline for building and releasing the Flight iconset as a set of packages in different formats, that can be consumed by other tools and products.
 
----
-
-## Usage
-
 The pipeline can be run manually, on your local machine, or via GitHub actions.
 
-There are three distinct steps in the process:
+-----
 
-### Sync
+## Releasing a new npm version of the package
 
-The synchronization step is executed by the `/scripts/sync.ts` file. To run this script use the following command in your CLI:
+Whenever there is an update to the Flight Icons library in Figma (eg. a new icon is added), these changes need to be transfered also to the code. This means re-syncing and re-building the `flight-icons` package and then release it to the npm registry.
 
-```bash
-yarn sync
-```
+_Remember: once released a package on the public registry, you can't revert the changes: the only solution is to deprecate the package (this will hide it from the public, but remains there)._
 
-This action will:
+The update process for the icons should happen in a dedicated branch, associated with the GitHub task/issue. Once you have run the `yarn sync` and `yarn build` (see the instructions below), check the diff in your git client, and once you're OK with them commit the changes to the branch, push and then ask for a pull request.
 
-* Retrieve the assets metadata from Figma via REST API
-* Export the assets as `.svg` files into `./svg-original/`
-* Generate the `catalog.json` file
+Once this request has been approved and the branch merged in `main`, you can publish the package (using directly the `main` branch, no need to create a new PR for this) using the `release` command (see the instructions below).
 
-### Build
 
-The build step is executed by the `/scripts/build.ts` file. To run this script use the following command in your CLI:
+## Initial setup
 
-```bash
-yarn build
-```
-
-This action will:
-
-* Optimize the SVG files and save then in a `temp` folder
-* Process the optimized SVG files and save then in the `svg` folder
-* Update the existing files in the Ember addon folder:
-    * Process the optimized SVG, generate a SVG sprite, and overwrite the existing sprite
-    * Overwrite the catalog.json with the new one
-
-### Release
-
-The release step is executed using a set of NPM scripts defined in the `package.json` file.
-
-This action will:
-
-* ask (interactively) the user which _semver_ version they want to to use
-* update the `package.json` file with that version
-* release the bundle on the [NPM registry](https://www.npmjs.com/)
-
-**IMPORTANT**: if you need to do some tests, use a **local** package registry, not production! (see below)
-
-### Code check
-
-You can also do some important sanity checks to the code via the commands:
-
-```bash
-# check type safety
-yarn typecheck
-
-# check code syntax
-yarn lint
-```
-
-## Local development
-
-To run the scripts locally, follow these steps.
-
-### Setup
 
 *Notice: [Node.js](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/getting-started/install) needs to be installed on your local machine.*
 
@@ -81,7 +31,7 @@ git clone https://github.com/hashicorp/flight
 Then install the project dependencies:
 
 ```bash
-# go to the "scripts" folder
+# go to the "main" folder
 cd /[your-local-project-path]/flight-icons
 
 # install node modules
@@ -102,47 +52,81 @@ where `###` is your personal access token. You can use the `.env.template` file 
 
 **IMPORTANT**: the `.env` file is ignored by git, and should not be committed to the repository.
 
-### Running the scripts
 
-Finally, you can run the scripts commands via CLI:
+Once you've done the initial setup, there are three distinct steps in the process that you can follow.
+
+## Sync
+
+The synchronization step is executed by the `/scripts/sync.ts` file. To run this script launch the following commands in your CLI (while in the `flight-icons` folder):
 
 ```bash
-# sync
 yarn sync
-
-# build
-yarn build
-
-# release - CAREFUL: this will publish the package on NPM! Use a local package registry for testing (see below)
-yarn release
 ```
 
-## Releasing a new npm version of the package
+This action will:
 
-Whenever there is an update in the Flight icons Figma library (eg. a new icon added) these changes need to be ported also on the code side. This means re-syncing and re-building the `flight-icons` package and then release it to the npm registry.
+* Retrieve the assets metadata from Figma via REST API
+* Export the assets as `.svg` files into `./svg-original/`
+* Generate the `catalog.json` file
 
-_Remember: once released a package on the public registry, it's not simple to undo it._
+## Build
 
-The update process for the icons should happen in a dedicated branch, associated with the GitHub task/issue. Once you have run the `yarn sync` and `yarn build`, check the diff in your git client, and once you're OK with them commit the changes to the branch, push and then ask for a pull request.
-
-Once this request has been approved and the branch merged in `main`, you can publish the package (using directly the `main` branch, no need to create a new PR for this) -- [TODO! to be discussed with the team].
-
-Run the following command:
+The build step is executed by the `/scripts/build.ts` file. To run this script use the following command in your CLI (while in the `flight-icons` folder):
 
 ```bash
-cd flight-icons
+yarn build
+```
+
+This action will:
+
+* Optimize the SVG files and save then in a `temp` folder
+* Process the optimized SVG files and save then in the `svg` folder
+* Update the existing files in the Ember addon folder:
+    * Process the optimized SVG, generate a SVG sprite, and overwrite the existing sprite
+    * Overwrite the catalog.json with the new one
+
+## Release
+
+The release step is executed using a set of NPM scripts defined in the `package.json` file. Use the following command in your CLI (while in the `flight-icons` folder):
+
+
+```bash
 yarn release
 ```
 
-The `bump` command will interactively ask you which _semver_ version you want to use for the bump: you can move up and down with the keyboard, choose one option, and then hit "enter".
+This action will:
 
-At this point the script automatically will bump the version in the `package.json` file, and publish the new version of the `flight-icons` package.
+* ask (interactively*) the user which _semver_ version they want to to use
+	* the `bump` command will interactively ask you which semver version you want to use: you can move up and down with the keyboard, choose one option, and then hit "enter".
+* update the `package.json` file with that version
+* release the bundle on the [NPM registry](https://www.npmjs.com/)
+
+The script will automatically bump the version in the `package.json` file, and publish the new version of the `flight-icons` package.
 
 _Notice: you will need a company-approved account on npm (with 2FA) to publish._
 
 At this point check on [www.npmjs.com/package/@hashicorp/flight-icons](https://www.npmjs.com/package/@hashicorp/flight-icons) that the package has been successfully published (under the "versions" tab) and you're good. Well done you just published your new package! 🎉
 
-# Using a local NPM registry for testing
+**IMPORTANT**: if you need to do some tests, use a **local** package registry, not production! (see below)
+
+
+## Local development
+
+If you need to work on the scripts locally, here some useful information.
+
+### Code check
+
+You can also do some important sanity checks to the code via the commands:
+
+```bash
+# check type safety
+yarn typecheck
+
+# check code syntax
+yarn lint
+```
+
+### Using a local NPM registry for testing
 
 To test the release of packages without actually polluting the real/production npm registry, you cansetup a local registry using [Verdaccio](https://verdaccio.org/docs/what-is-verdaccio), an open source solution, very easy to setup and use.
 
@@ -162,7 +146,7 @@ Now you need to add this entry in the `package.json` files of `flight-icons`:
 
 This will make sure the package is published on Verdaccio. Once the package is published, the web frontend accesible at http://localhost:4873/ will show you all the details about the packages (and if needed you can also download the tarballs, to check their content).
 
-_Notice: once you've done testing, you can remove verdaccio via `npm uninstall -g verdaccio` and then remove the files he created using `rm -fr ~/.local/share/verdaccio && rm -fr .config/verdaccio`. You can use the same command to cleanup the entire data storage of Verdaccio and start from scratch (no need to reinstall for this, just cleanup the data)._
+Once you've done testing, you can remove verdaccio via `npm uninstall -g verdaccio` and then remove the files he created using `rm -fr ~/.local/share/verdaccio && rm -fr .config/verdaccio`. You can use the same command to cleanup the entire data storage of Verdaccio and start from scratch (no need to reinstall for this, just cleanup the data).
 
 ## 🚧 [WIP] GitHub action
 


### PR DESCRIPTION
## :pushpin: Summary

This is the last part of the PR to solve #188. 

In this PR I have:
- updated the CONTRIBUTE documentation for both the `flight-icons` and `ember-flight-icons`, reorganizing some content and adding specific instructions to follow for the "release" of npm packages.
- made a small change to a path in the documentation for developers in the mini-website