### PR TITLE
Add percy-test route with snapshot test

### DIFF
--- a/ember-flight-icons/tests/acceptance/index-test.js
+++ b/ember-flight-icons/tests/acceptance/index-test.js
@@ -4,7 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import waitFor from '@ember/test-helpers/dom/wait-for';
 import percySnapshot from '@percy/ember';
 
-module('Acceptance | icon index', function (hooks) {
+module('Acceptance | icon index and percy-test', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting / renders a list of icons', async function (assert) {
@@ -15,5 +15,13 @@ module('Acceptance | icon index', function (hooks) {
     assert.dom('[data-test-target="icon-grid"] [data-test-icon]').exists();
 
     await percySnapshot('Icons page');
+  });
+
+  test('visiting /percy-test', async function (assert) {
+    await visit('/percy-test');
+
+    await percySnapshot('Percy test page');
+
+    assert.ok(true);
   });
 });

--- a/ember-flight-icons/tests/dummy/app/router.js
+++ b/ember-flight-icons/tests/dummy/app/router.js
@@ -9,4 +9,5 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('engineering');
   this.route('design');
+  this.route('percy-test');
 });

--- a/ember-flight-icons/tests/dummy/app/routes/percy-test.js
+++ b/ember-flight-icons/tests/dummy/app/routes/percy-test.js
@@ -1,0 +1,5 @@
+/* eslint-disable */
+// Route name including "test" causes N/A eslint error
+import Route from '@ember/routing/route';
+
+export default class PercyTestRoute extends Route {}

--- a/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
@@ -1,0 +1,50 @@
+{{page-title "Percy test"}}
+
+<h1 class="ds-h1">Percy test page</h1>
+<h2 class="ds-h2">Note: This route is hidden from nav, for testing only 🤙</h2>
+<br>
+
+<div>
+  <p>Icon with default size (16):</p>
+  <FlightIcon @name="bug"></FlightIcon>
+</div>
+<br>
+
+<div>
+  <p>Icon with larger size (24):</p>
+  <FlightIcon @name="bug" @size="24"></FlightIcon>
+</div>
+<br>
+<hr>
+<br>
+
+<div>
+  <p>Icon with unspecified color (currentColor):</p>
+  <FlightIcon @name="bookmark"></FlightIcon>
+</div>
+<br>
+
+<div>
+  <p>Icon with custom red color, specified via prop:</p>
+  <FlightIcon @name="folder-fill" @color="red"></FlightIcon>
+</div>
+<br>
+<hr>
+<br>
+
+<div>
+  <p>Icon with unspecified color (currentColor) + parent with custom blue color (to check inheritance)</p>
+  {{!-- template-lint-disable no-inline-styles --}}
+  <a style="color:blue" href="">
+    <FlightIcon @name="external-link"></FlightIcon>
+  </a>
+</div>
+<br>
+
+<div>
+  <p>Icon with custom orange color, specified via prop + parent with !important green color declared (to check overrides not working)</p>
+  {{!-- template-lint-disable no-inline-styles --}}
+  <div style="color:green !important">
+    <FlightIcon @name="heart-fill" @color="orange"></FlightIcon>
+  </div>
+</div>


### PR DESCRIPTION
## :pushpin: Summary

Additional test to test icons in isolation. Route is hidden, have to manually navigate to /percy-test in the browser. If we added or removed an icon, the index Percy test diff would not be helpful at all.

Resolves: https://github.com/hashicorp/flight/issues/231