### PR TITLE
Split the “bump” command from the actual “publish” action

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -55,9 +55,8 @@
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
     "test:ember:percy": "percy exec ember test",
-    "release:bump": "./node_modules/.bin/bump package.json",
-    "release:publish": "yarn publish --new-version $npm_package_version",
-    "release": "yarn release:bump && yarn release:publish"
+    "bump": "./node_modules/.bin/bump package.json",
+    "release": "yarn publish --new-version $npm_package_version"
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",

--- a/flight-icons/package.json
+++ b/flight-icons/package.json
@@ -42,9 +42,8 @@
     "lint": "yarn eslint --quiet --ext .js,.ts",
     "sync": "ts-node --transpile-only ./scripts/sync",
     "build": "ts-node --transpile-only ./scripts/build",
-    "release:bump": "./node_modules/.bin/bump package.json",
-    "release:publish": "yarn publish --new-version $npm_package_version",
-    "release": "yarn release:bump && yarn release:publish"
+    "bump": "./node_modules/.bin/bump package.json",
+    "release": "yarn publish --new-version $npm_package_version"
   },
   "devDependencies": {
     "@figma-export/cli": "^3.4.0",


### PR DESCRIPTION
## :pushpin: Summary

I have split the “bump” command from the actual “npm publish” action. In this way they can be run independently, and we can have a specific PR on the update of the version (per conversation in: https://github.com/hashicorp/flight/pull/229#discussion_r710986676)