### PR TITLE
Bugfix: resolves Safari issue

### DIFF
--- a/ember-flight-icons/tests/dummy/app/styles/components/ds-icon-grid.css
+++ b/ember-flight-icons/tests/dummy/app/styles/components/ds-icon-grid.css
@@ -47,10 +47,10 @@
 
 .ds-input-search {
   @apply 
-    block
     border-gray-300
     focus:border-brand
     focus:ring-brand
+    inline-block
     pl-10
     rounded-md
     shadow-sm


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR resolves issue where a Safari bug was preventing correct use of the live-filter on the icons. 

Resolves #228 


### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
