### PR TITLE
Add manual real-world QA instructions

### DIFF
--- a/ember-flight-icons/CONTRIBUTING.md
+++ b/ember-flight-icons/CONTRIBUTING.md
@@ -56,10 +56,11 @@ _**IMPORTANT**: if you need to do some tests, use a **local** package registry (
 
 ### How to do some manual QA of the new package version
 
-- Bump the `@hashicorp/ember-flight-icons` version in [hashicorp/design-system-playground/blob/main/package.json](https://github.com/hashicorp/design-system-playground/blob/main/package.json)
-- `yarn`
-- `ember s`
-- Confirm you see icon on the homepage in local dev.
+You may want to test the change in the real-world, with a consuming app, to test for any gotchas that could come up in production.
+
+- Bump the `@hashicorp/ember-flight-icons` version in [this WIP PR in `cloud-ui`](https://github.com/hashicorp/cloud-ui/pull/1322)
+- Run the PR locally
+- Confirm you see icons, such as the external link icon, on the homepage once you're logged in.
 
 ## Testing local changes to the addon
 

--- a/ember-flight-icons/CONTRIBUTING.md
+++ b/ember-flight-icons/CONTRIBUTING.md
@@ -54,6 +54,13 @@ In the second step you publish the package on the npm registry:
 
 _**IMPORTANT**: if you need to do some tests, use a **local** package registry (see [CONTRIBUTING](../flight-icons/CONTRIBUTING.md) in the `flight-icon`), don't test directly in production!_
 
+### How to do some manual QA of the new package version
+
+- Bump the `@hashicorp/ember-flight-icons` version in [hashicorp/design-system-playground/blob/main/package.json](https://github.com/hashicorp/design-system-playground/blob/main/package.json)
+- `yarn`
+- `ember s`
+- Confirm you see icon on the homepage in local dev.
+
 ## Testing local changes to the addon
 
 - `cd flight/ember-flight-icons`

--- a/flight-icons/CONTRIBUTING.md
+++ b/flight-icons/CONTRIBUTING.md
@@ -172,6 +172,13 @@ At this point check on [www.npmjs.com/package/@hashicorp/flight-icons](https://w
 
 🚨 **DON'T FORGET**: if you're releasing a new version of `@hashicorp/flight-icons`, this means that during the `build` step the SVG sprite and the `catalog.json` file in the `ember-flight-icons/` have also been updated, which means you have to release also that package.
 
+### How to do some manual QA of the new package version
+
+- Bump the `@hashicorp/flight-icons` version in [hashicorp/boundary-ui/blob/main/addons/rose/package.json](https://github.com/hashicorp/boundary-ui/blob/main/addons/rose/package.json)
+- At root, run `yarn`
+- `cd ui/desktop && yarn start`
+- Confirm you see icons in local dev.
+
 ## Local development
 
 If you need to work on the scripts locally, here some useful information.

--- a/flight-icons/CONTRIBUTING.md
+++ b/flight-icons/CONTRIBUTING.md
@@ -174,6 +174,8 @@ At this point check on [www.npmjs.com/package/@hashicorp/flight-icons](https://w
 
 ### How to do some manual QA of the new package version
 
+You may want to test the change in the real-world, with a consuming app, to test for any gotchas that could come up in production.
+
 - Bump the `@hashicorp/flight-icons` version in [hashicorp/boundary-ui/blob/main/addons/rose/package.json](https://github.com/hashicorp/boundary-ui/blob/main/addons/rose/package.json)
 - At root, run `yarn`
 - `cd ui/desktop && yarn start`


### PR DESCRIPTION
## :pushpin: Summary

Resolves: part of https://github.com/hashicorp/flight/issues/240

One more tweak to the instructions, seems like following this PR, @MelSumner can give https://github.com/hashicorp/flight/issues/240 a try at any point that's convenient this week.