### PR TITLE
Fix link

### DIFF
--- a/ember-flight-icons/tests/dummy/app/templates/design.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/design.hbs
@@ -404,9 +404,7 @@
         href="https://github.com/hashicorp/flight/issues/new?assignees=&labels=enhancement%2C+triage&template=icon-request.md&title=Flight+Icon+Request%3A+%5Bicon-name%5D"
         class="ds-a"
         rel="external"
-      >
-        Open a GitHub issue
-      </a>
+      >Open a GitHub issue</a>
       to kick-off work on adding a new icon
     </li>
     <li>

--- a/ember-flight-icons/tests/dummy/app/templates/design.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/design.hbs
@@ -215,9 +215,7 @@
         href="https://www.figma.com/file/TLnoT5AYQfy3tZ0H68BgOr/Flight-Icons?node-id=164%3A0"
         rel="external"
         class="ds-a"
-      >
-        Flight Icons
-      </a>
+      >Flight Icons</a>
       Library clicking on the toggle next to the name
     </li>
     <li>


### PR DESCRIPTION
## :pushpin: Summary

Small change to fix link including whitespace

Could potentially be prevented in the future w/something like https://github.com/hashicorp/flight/pull/233

## :camera_flash: Screenshots

WAS:
![image](https://user-images.githubusercontent.com/1372946/134091133-48cc3129-15cc-462a-93fd-68553a84ee73.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/134091196-85b0be6d-3dbc-46ce-b0fd-d3208e7ceb0f.png)

Also found and updated:
![image](https://user-images.githubusercontent.com/1372946/134091865-e12b73aa-cf51-495f-b5c1-fb229491233e.png)
