### PR TITLE
[WIP] Fix pre styling: looking for feedback, then can make change thruout

### DIFF
--- a/ember-flight-icons/tests/dummy/app/styles/app.css
+++ b/ember-flight-icons/tests/dummy/app/styles/app.css
@@ -33,6 +33,7 @@ html {
   font-family: var(--font-body);
   font-size: var(--font-size-default);
 }
+
 body.ds-body {
   line-height: 1.2;
   @apply
@@ -43,6 +44,7 @@ body.ds-body {
   min-h-screen
   p-0;
 }
+
 header.ds-header {
   @apply
   bg-brand
@@ -58,13 +60,11 @@ main.ds-main {
     sm:container;
 }
 
-
 .ds-kbd {
   color: #D10070; /* to coordinate with the current prism theme */
   font-size: 0.9em;
   @apply
   font-bold;
-  
 }
 
 .ds-info {
@@ -78,20 +78,14 @@ main.ds-main {
   rounded-md
   md:max-w-4xl
   lg:max-w-3xl;
-
 }
+
 img.ds-img {
   @apply
   block
   h-auto
   max-w-full;
 }
-
-
-.prose-lg pre.language-markup {
-  @apply mt-0;
-}
-
 
 /* if you have other custom utility classes, add them here. */
 @layer utilities {

--- a/ember-flight-icons/tests/dummy/app/templates/design.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/design.hbs
@@ -10,7 +10,7 @@
   </h2>
   <ul>
     <li>
-      Display icons at either `16px` or `24px`
+      Display icons at either <span class="font-mono text-gray-900 font-bold">16px</span> or <span class="font-mono text-gray-900 font-bold">24px</span>
     </li>
     <li>
       Use `16px` icons by default in product interfaces


### PR DESCRIPTION
## :pushpin: Summary

Change `<pre>` styling which is currently markdown backticks

What do you think of this change, used what's on https://tailwindcss.com/

Note: I'm not sure the context behind the `prose` class, it's bringing in a lot of cascading classes. If it were me I would remove `prose prose-lg` and have the typography be atomic. Then could just set the styling for `pre`. But for now, I'm just trying to make an incremental change to improve the look and feel of the page

If you like this change, can swap out all the backticks

## :camera_flash: Screenshots

WAS:
![image](https://user-images.githubusercontent.com/1372946/134092825-48d23329-3398-464e-b27a-8370e6f6e748.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/134092798-7733f7bb-1ba9-40cb-98a4-24798331fabf.png)

