### PR TITLE
yarn bump for rc

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/ember-flight-icons",
-  "version": "0.0.3-beta",
+  "version": "0.0.3-rc",
   "description": "The Ember addon for the HashiCorp Flight SVG icon set",
   "keywords": [
     "ember-addon",

--- a/ember-flight-icons/public/icons/catalog.json
+++ b/ember-flight-icons/public/icons/catalog.json
@@ -1,5 +1,5 @@
 {
-  "lastRunTimeISO": "2021-09-16T17:28:24.935Z",
+  "lastRunTimeISO": "2021-09-22T16:26:08.317Z",
   "lastRunFigma": {
     "id": "TLnoT5AYQfy3tZ0H68BgOr",
     "page": "Export",

--- a/flight-icons/package.json
+++ b/flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/flight-icons",
-  "version": "0.0.9-beta",
+  "version": "0.0.9-rc",
   "description": "Flight: HashiCorp SVG icon set",
   "keywords": [
     "hashicorp",


### PR DESCRIPTION
## :pushpin: Summary

 If merged, this PR bumps `flight-icons` to v0.0.9-rc and `ember-flight-icons` to v0.0.3-rc. 