### PR TITLE
Add automatic git tagging to "release" step

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -56,7 +56,8 @@
     "test:ember-compatibility": "ember try:each",
     "test:ember:percy": "percy exec ember test",
     "bump": "./node_modules/.bin/bump package.json",
-    "release": "yarn publish --new-version $npm_package_version"
+    "release": "yarn publish --new-version $npm_package_version",
+    "postrelease": "TAG_VERSION=\"@hashicorp/ember-flight-icons/${npm_package_version}\" && git tag $TAG_VERSION && git push origin $TAG_VERSION"
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",

--- a/flight-icons/package.json
+++ b/flight-icons/package.json
@@ -43,7 +43,8 @@
     "sync": "ts-node --transpile-only ./scripts/sync",
     "build": "ts-node --transpile-only ./scripts/build",
     "bump": "./node_modules/.bin/bump package.json",
-    "release": "yarn publish --new-version $npm_package_version"
+    "release": "yarn publish --new-version $npm_package_version",
+    "postrelease": "TAG_VERSION=\"@hashicorp/flight-icons/${npm_package_version}\" && git tag $TAG_VERSION && git push origin $TAG_VERSION"
   },
   "devDependencies": {
     "@figma-export/cli": "^3.4.0",


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR will add `git tag` to the `release` step (as requested by @Dhaulagiri).

Notice: this is the format I am using, but open to suggestions if you have a better idea:
https://github.com/hashicorp/flight/tags