### PR TITLE
don't finger print sprite file

### DIFF
--- a/ember-flight-icons/ember-cli-build.js
+++ b/ember-flight-icons/ember-cli-build.js
@@ -5,9 +5,6 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
-    fingerprint: {
-      exclude: ['flight-icon-sprite'],
-    },
     postcssOptions: {
       compile: {
         enabled: true,


### PR DESCRIPTION
file is no longer part of this addon

## :pushpin: Summary

With https://github.com/hashicorp/flight/pull/271 this is no longer necessary


## :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

Verify things are working in vercel


## :+1: Definition of Done

- [x] New functionality works 

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
