### PR TITLE
bump for 1.0 release

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/ember-flight-icons",
-  "version": "0.0.6-rc",
+  "version": "1.0.0",
   "description": "The Ember addon for the HashiCorp Flight SVG icon set",
   "keywords": [
     "ember-addon",

--- a/flight-icons/package.json
+++ b/flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/flight-icons",
-  "version": "0.0.12-rc",
+  "version": "1.0.0",
   "description": "Flight: HashiCorp SVG icon set",
   "keywords": [
     "hashicorp",


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR bumps the version of `flight-icons` and `ember-flight-icons` to v1.0.0

