### PR TITLE
Add Percy back, works now

### DIFF
--- a/.github/workflows/ci-ember-flight-icons.yml
+++ b/.github/workflows/ci-ember-flight-icons.yml
@@ -122,10 +122,10 @@ jobs:
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
-    # - name: Test
-    #   run: yarn test:ember:percy --launch ${{ matrix.browser }}
-    #   env:
-    #     PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+    - name: Test
+      run: yarn test:ember:percy --launch ${{ matrix.browser }}
+      env:
+        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
   floating-dependencies:
     name: Floating Dependencies
@@ -166,10 +166,10 @@ jobs:
     - name: Install Dependencies
       run: yarn install --no-lockfile --non-interactive
 
-    # - name: Test
-    #   run: yarn test:ember:percy --launch ${{ matrix.browser }}
-    #   env:
-    #     PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+    - name: Test
+      run: yarn test:ember:percy --launch ${{ matrix.browser }}
+      env:
+        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
   try-scenarios:
     name: Tests - ${{ matrix.ember-try-scenario }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ flight-icons/temp
 
 # Output of `npm pack`, which is an (optional) test for `npm publish`
 *.tgz
+
+# Used for Percy debugging
+snapshots.yml

--- a/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
@@ -1,6 +1,6 @@
 {{page-title "Percy test"}}
 
-<h1 class="ds-h1">Percy test page</h1>
+<h1 class="ds-h1">Percy test page!</h1>
 <h2 class="ds-h2">Note: This route is hidden from nav, for testing only 🤙</h2>
 <br />
 


### PR DESCRIPTION
I have a support thread going with Percy. Not sure what changed but the svg's appear on Percy now. So let's add this back. I emailed them to ask why.

Please check out the Percy at the bottom and approve it!

Reverts hashicorp/flight#266