### PR TITLE
Change ember-test-selectors to peerDependency

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/ember-flight-icons",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The Ember addon for the HashiCorp Flight SVG icon set",
   "keywords": [
     "ember-addon",
@@ -62,8 +62,7 @@
   "dependencies": {
     "@hashicorp/flight-icons": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^5.7.1",
-    "ember-test-selectors": "^6.0.0"
+    "ember-cli-htmlbars": "^5.7.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -116,6 +115,9 @@
     "tailwindcss": "^2.2.11",
     "version-bump-prompt": "^6.1.0",
     "webpack": "^5.57.1"
+  },
+  "peerDependencies": {
+    "ember-test-selectors": "^6.0.0"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"

--- a/ember-flight-icons/yarn.lock
+++ b/ember-flight-icons/yarn.lock
@@ -5034,7 +5034,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.20.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.20.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -5696,15 +5696,6 @@ ember-template-recast@^5.0.3:
     slash "^3.0.0"
     tmp "^0.2.1"
     workerpool "^6.1.4"
-
-ember-test-selectors@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-6.0.0.tgz#ba9bb19550d9dec6e4037d86d2b13c2cfd329341"
-  integrity sha512-PgYcI9PeNvtKaF0QncxfbS68olMYM1idwuI8v/WxsjOGqUx5bmsu6V17vy/d9hX4mwmjgsBhEghrVasGSuaIgw==
-  dependencies:
-    calculate-cache-key-for-tree "^2.0.0"
-    ember-cli-babel "^7.26.4"
-    ember-cli-version-checker "^5.1.2"
 
 ember-truth-helpers@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## :pushpin: Summary

Will allow consuming apps to use a different version

Resolves: https://github.com/hashicorp/flight/issues/284

In my mind, this change would also bump `@hashicorp/ember-flight-icons` to a 1.1.0 so wanted to be sure we're on the same SemVer page.

//

This change seemed fine to me because we need ember-test-selectors to be under `dependencies` instead of `devDependencies`.

For context, there was an internal [Slack thread about testing strategy](https://hashicorp.slack.com/archives/C11JCBJTW/p1631731593173900) but the context is: we made a decision to include `data-test-` in the FlightIcon component. I personally was of the opinion that we can leave the testing up to the consuming app. (If we went that route, `ember-test-selectors` could be under `devDependencies`.) But I think what we have now is great, and should move forward with this PR as-is if you agree.

- [ ] Update https://github.com/hashicorp/cloud-ui/pull/1428 if this is merged
- [ ] Publish version bump to npm if this is merged

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
