### PR TITLE
Ignore dependabots for @types/svgo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
+    ignore: 
+      dependency-name: "@types/svgo"
   - package-ecosystem: "npm" 
     directory: "ember-flight-icons/" 
     versioning-strategy: increase


### PR DESCRIPTION
Ref: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore

Follow-on to: https://github.com/hashicorp/flight/pull/298

Replace https://github.com/hashicorp/flight/pull/305, the license CLA and tests are failing, seemed like something was wrong with the CLA yesterday