### PR TITLE
Ignore dependabots for "svgo"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore: 
+      dependency-name: "svgo"
       dependency-name: "@types/svgo"
   - package-ecosystem: "npm" 
     directory: "ember-flight-icons/" 


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR will add "svgo" to the dependencies ignored by dependabot.

The reason is that we're using SVGO vs 1.3.2 **on purpose**:

https://github.com/hashicorp/flight/blob/a0b6b29d728a7b510ef9517091b81038a5cc2797/flight-icons/scripts/build-parts/optimizeAssetsSVG.ts#L4-L7

(see also #298 / #309)