### PR TITLE
use flight-icons 1.2.0

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -60,7 +60,7 @@
     "postrelease": "TAG_VERSION=\"@hashicorp/ember-flight-icons/${npm_package_version}\" && git tag $TAG_VERSION && git push origin $TAG_VERSION"
   },
   "dependencies": {
-    "@hashicorp/flight-icons": "^1.1.0",
+    "@hashicorp/flight-icons": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-test-selectors": "^6.0.0"

--- a/ember-flight-icons/yarn.lock
+++ b/ember-flight-icons/yarn.lock
@@ -1436,10 +1436,10 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
   integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
-"@hashicorp/flight-icons@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-1.1.0.tgz#3e09536cc651970eca95d62f8ad6ca5ffe487aef"
-  integrity sha512-6K2nA41kZP9WUlnfo64n02aXnAfWqWZLUllQx8PQ7o0RwumxV8zuCMlg2ANPCAdNwiluO8P6OGRcHXmI9X05GA==
+"@hashicorp/flight-icons@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-1.2.0.tgz#b3b61a24f7a7921d20ce4c3c49a2f63956f05f80"
+  integrity sha512-gMsPGbDXSBWe4v7sFjG+ZlQdc8ipNLi5w98muaKU5tUNG027b5XNy5chkiT1/gsygi5ZlKXU0klgC0JHZ44B8A==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## :pushpin: Summary

<!-- If merged, this PR.... 
This should be a short TL;DR that includes the purpose of the PR.
-->
This will update the docs site to use the most recent version of flight-icons, including the icons added in #318 

## :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

## :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

Look at the preview app and look for EKS and EC2 icons

## :+1: Definition of Done

- [x] New functionality works 

### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

Examples: 
- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
- suggestion (non-blocking): Let's change this wording to make it easier to understand.
- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
