### PR TITLE
ember flight icon liquid size

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.hbs
+++ b/ember-flight-icons/addon/components/flight-icon.hbs
@@ -1,5 +1,5 @@
 <svg
-  class="flight-icon flight-icon-{{@name}} {{if this.display "flight-icon-display-inline"}}"
+  class="flight-icon flight-icon-{{@name}} {{this.displayClass}}"
   ...attributes
   aria-hidden="{{if @title "false" "true"}}"
   aria-labelledby={{this.ariaLabelledby}}
@@ -7,8 +7,8 @@
   fill="{{this.color}}"
   id={{this.iconId}}
   role={{this.role}}
-  width="{{this.size}}"
-  height="{{this.size}}"
+  width="{{this.svgSize.width}}"
+  height="{{this.svgSize.height}}"
   viewBox="0 0 {{this.size}} {{this.size}}"
   xmlns="http://www.w3.org/2000/svg"
 >

--- a/ember-flight-icons/addon/components/flight-icon.js
+++ b/ember-flight-icons/addon/components/flight-icon.js
@@ -44,14 +44,16 @@ export default class FlightIconComponent extends Component {
   }
 
   /**
-   * Determines the icon's `display` property
-   *
-   * @param display
-   * @returns the value of `isInlineBlock` if set
-   * @default true
+   * Get a class to apply to the icon based on the display argument.
+   * @method FlightIcon#displayClass
+   * @return {string} The css class to apply to the SVG.
    */
-  get display() {
-    return this.args.isInlineBlock ?? true;
+  get displayClass() {
+    if (this.args.isInlineBlock && !this.args.stretched) {
+      return 'flight-icon-display-inline';
+    } else {
+      return null;
+    }
   }
 
   /**
@@ -63,6 +65,18 @@ export default class FlightIconComponent extends Component {
    */
   get size() {
     return this.args.size ?? '16';
+  }
+
+  /**
+   * Get the SVG width/height depending if the icon is stretched or not
+   * @method FlightIcon#svgSize
+   * @return {object} The width/height to apply to the SVG.
+   */
+  get svgSize() {
+    return {
+      width: this.args.stretched ? '100%' : this.size,
+      height: this.args.stretched ? '100%' : this.height,
+    };
   }
 
   /**

--- a/ember-flight-icons/addon/components/flight-icon.js
+++ b/ember-flight-icons/addon/components/flight-icon.js
@@ -49,7 +49,8 @@ export default class FlightIconComponent extends Component {
    * @return {string} The css class to apply to the SVG.
    */
   get displayClass() {
-    if (this.args.isInlineBlock && !this.args.stretched) {
+    const isInlineBlock = this.args.isInlineBlock ?? true;
+    if (isInlineBlock && !this.args.stretched) {
       return 'flight-icon-display-inline';
     } else {
       return null;

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -79,8 +79,8 @@
       <li class="ds-li"><code class="ds-code">height</code>
         and
         <code class="ds-code">width</code>: default size of 16x16 (px)</li>
-      <li class="ds-li"><code class="ds-code">stretched</code>: if the SVG should have 100% width/height
-        (stretch to fill the parent) - defaults to "false"</li>
+      <li class="ds-li"><code class="ds-code">stretched</code>: if the SVG should have 100% width/height (stretch to
+        fill the parent) - defaults to "false"</li>
       <li class="ds-li">(CSS)
         <code class="ds-code">class</code>: flight-icon, flight-icon-NAME, flight-icon-display-inline</li>
       <li class="ds-li">CSS display: set to

--- a/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/engineering.hbs
@@ -79,6 +79,8 @@
       <li class="ds-li"><code class="ds-code">height</code>
         and
         <code class="ds-code">width</code>: default size of 16x16 (px)</li>
+      <li class="ds-li"><code class="ds-code">stretched</code>: if the SVG should have 100% width/height
+        (stretch to fill the parent) - defaults to "false"</li>
       <li class="ds-li">(CSS)
         <code class="ds-code">class</code>: flight-icon, flight-icon-NAME, flight-icon-display-inline</li>
       <li class="ds-li">CSS display: set to
@@ -135,6 +137,7 @@
     <ol>
       <li>fill (the color)</li>
       <li>size (at this time, only 16 (default) and 24 are supported)</li>
+      <li>stretched (true/false)</li>
       <li>display (inline-block or block)</li>
       <li>additional CSS classes</li>
     </ol>
@@ -179,6 +182,21 @@
     <CodeBlock @language="markup" @code="&lt;FlightIcon @name=&quot;zap&quot; @size=&quot;24&quot; />" />
     {{! prettier-ignore-start }}
   </p>
+
+  <p id="example-stretch">
+    <strong><a href="#example-stretch" class="ds-a" rel="external">&sect;</a>
+      Stretched:</strong>
+    To have the icon fill the parent container (width: 100%, height: 100%, display: block), set the
+    <code class="ds-code">@stretched</code>
+    attribute:
+    {{! prettier-ignore-start }}
+    <CodeBlock
+      @language="markup"
+      @code="&lt;FlightIcon @name=&quot;zap&quot; @size=&quot;24&quot; @stretched=&quot;true&quot; />"
+    />
+    {{! prettier-ignore-start }}
+  </p>
+
   <p id="example-styles">
     <strong><a href="#example-styles" class="ds-a" rel="external">&sect;</a>
       CSS Classes:</strong>

--- a/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
@@ -22,7 +22,7 @@
     <div class="w-3 h-3">
       <FlightIcon @name="bug" @size="16" @stretched="true" />
     </div>
-    <div class="w-8 w-8">
+    <div class="w-8 h-8">
       <FlightIcon @name="bug" @size="24" @stretched="true" />
     </div>
   </div>

--- a/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
+++ b/ember-flight-icons/tests/dummy/app/templates/percy-test.hbs
@@ -15,6 +15,19 @@
   <FlightIcon @name="bug" @size="24" />
 </div>
 <br />
+
+<div>
+  <p>Icon with custom sizes (12/32):</p>
+  <div class="flex gap-0.5">
+    <div class="w-3 h-3">
+      <FlightIcon @name="bug" @size="16" @stretched="true" />
+    </div>
+    <div class="w-8 w-8">
+      <FlightIcon @name="bug" @size="24" @stretched="true" />
+    </div>
+  </div>
+</div>
+<br />
 <hr />
 <br />
 

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -41,13 +41,21 @@ module('Integration | Component | flight-icon', function (hooks) {
       .hasAttribute('width', '100%')
       .hasAttribute('height', '100%');
   });
-  test('it does not have the display-inline class if the option is set to false', async function (assert) {
+  test('it does not have the "flight-icon-display-inline" class if the option is set to false', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @isInlineBlock={{false}} />`);
-    assert.dom('svg.flight-icon').doesNotHaveClass('display-inline');
+    assert
+      .dom('svg.flight-icon')
+      .doesNotHaveClass('flight-icon-display-inline');
   });
-  test('it does not have the display-inline class if the "stretched" option is set to true', async function (assert) {
+  test('it does have the "flight-icon-display-inline" class if the option is not set', async function (assert) {
+    await render(hbs`<FlightIcon @name="activity" />`);
+    assert.dom('svg.flight-icon').hasClass('flight-icon-display-inline');
+  });
+  test('it does not have the "flight-icon-display-inline" class if the "stretched" option is set to true', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @stretched={{true}} />`);
-    assert.dom('svg.flight-icon').doesNotHaveClass('display-inline');
+    assert
+      .dom('svg.flight-icon')
+      .doesNotHaveClass('flight-icon-display-inline');
   });
   test('additional classes can be added when component is invoked', async function (assert) {
     await render(hbs`<FlightIcon @name="meh" class="demo" />`);

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -8,9 +8,7 @@ module('Integration | Component | flight-icon', function (hooks) {
 
   test('it renders the icon', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
-    assert
-      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
-      .matchesSelector('svg');
+    assert.dom('svg.flight-icon.flight-icon-activity').matchesSelector('svg');
   });
   test('it should have a class name that is the same as the component name', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
@@ -19,29 +17,36 @@ module('Integration | Component | flight-icon', function (hooks) {
   test('it has aria-hidden set to true', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert
-      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
+      .dom('svg.flight-icon.flight-icon-activity')
       .hasAria('hidden', 'true');
   });
   test('it renders the 16x16 icon by default', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert
-      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
-      .hasStyle({
-        height: '16px',
-        width: '16px',
-      });
+      .dom('svg.flight-icon.flight-icon-activity')
+      .hasStyle({ height: '16px', width: '16px' });
   });
   test('it renders the 24x24 icon when option is set', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @size="24" />`);
     assert
-      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
-      .hasStyle({
-        height: '24px',
-        width: '24px',
-      });
+      .dom('svg.flight-icon.flight-icon-activity')
+      .hasStyle({ height: '24px', width: '24px' });
+  });
+  test('it sets the width/height to 100% when the "stretched" option is set to true', async function (assert) {
+    await render(
+      hbs`<FlightIcon @name="activity" @size="24" @stretched={{true}} />`
+    );
+    assert
+      .dom('svg.flight-icon.flight-icon-activity')
+      .hasAttribute('width', '100%')
+      .hasAttribute('height', '100%');
   });
   test('it does not have the display-inline class if the option is set to false', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @isInlineBlock={{false}} />`);
+    assert.dom('svg.flight-icon').doesNotHaveClass('display-inline');
+  });
+  test('it does not have the display-inline class if the "stretched" option is set to true', async function (assert) {
+    await render(hbs`<FlightIcon @name="activity" @stretched={{true}} />`);
     assert.dom('svg.flight-icon').doesNotHaveClass('display-inline');
   });
   test('additional classes can be added when component is invoked', async function (assert) {
@@ -77,19 +82,19 @@ module('Integration | Component | flight-icon', function (hooks) {
   test('it has aria-hidden set to false if a title is defined', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @title="try to avoid" />`);
     assert
-      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
+      .dom('svg.flight-icon.flight-icon-activity')
       .hasAria('hidden', 'false');
   });
   test('it has aria-labelledby if a title exists', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @title="try to avoid" />`);
     assert
-      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
+      .dom('svg.flight-icon.flight-icon-activity')
       .hasAttribute('aria-labelledby');
   });
   test('it does not have aria-labelledby if a title does not exist', async function (assert) {
-    await render(hbs`<FlightIcon @name="activity"  />`);
+    await render(hbs`<FlightIcon @name="activity" />`);
     assert
-      .dom('svg.flight-icon.flight-icon-activity.flight-icon-display-inline')
+      .dom('svg.flight-icon.flight-icon-activity')
       .doesNotHaveAttribute('aria-labelledby');
   });
   test('it has a g element with role of presentation if a title exists', async function (assert) {


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR will fix #327.

## :hammer_and_wrench: Detailed Description

I have:
- added support for the “stretched” prop in the “FlightIcon” Ember addon
- updated the “percy-test” page
- updated the "engineering" documentation
- updated the unit tests

At the beginning I thought to use the `size` parameter, with a `stretch` value, but then I realized we use it to extrapolate the asset name, so it would not work (how do we know in that case which one of the two assets in two different sizes to use?).

/cc @hashicorp/design-systems 