### PR TITLE
Bump “ember-flight-icons” to 1.2.0

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/ember-flight-icons",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The Ember addon for the HashiCorp Flight SVG icon set",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
## :pushpin: Summary

If merged, this PR will bump the `ember-flight-icons` addon to version 1.2.0.

_Notice: if you think this should be a `major` version change, happy to update it to `2.0.0`_