### PR TITLE
fix bug in flight-icon.js

### DIFF
--- a/ember-flight-icons/addon/components/flight-icon.js
+++ b/ember-flight-icons/addon/components/flight-icon.js
@@ -76,7 +76,7 @@ export default class FlightIconComponent extends Component {
   get svgSize() {
     return {
       width: this.args.stretched ? '100%' : this.size,
-      height: this.args.stretched ? '100%' : this.height,
+      height: this.args.stretched ? '100%' : this.size,
     };
   }
 

--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/ember-flight-icons",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The Ember addon for the HashiCorp Flight SVG icon set",
   "keywords": [
     "ember-addon",

--- a/ember-flight-icons/tests/integration/components/flight-icon-test.js
+++ b/ember-flight-icons/tests/integration/components/flight-icon-test.js
@@ -24,13 +24,17 @@ module('Integration | Component | flight-icon', function (hooks) {
     await render(hbs`<FlightIcon @name="activity" />`);
     assert
       .dom('svg.flight-icon.flight-icon-activity')
-      .hasStyle({ height: '16px', width: '16px' });
+      .hasStyle({ height: '16px', width: '16px' })
+      .hasAttribute('width', '16')
+      .hasAttribute('height', '16');
   });
   test('it renders the 24x24 icon when option is set', async function (assert) {
     await render(hbs`<FlightIcon @name="activity" @size="24" />`);
     assert
       .dom('svg.flight-icon.flight-icon-activity')
-      .hasStyle({ height: '24px', width: '24px' });
+      .hasStyle({ height: '24px', width: '24px' })
+      .hasAttribute('width', '24')
+      .hasAttribute('height', '24');
   });
   test('it sets the width/height to 100% when the "stretched" option is set to true', async function (assert) {
     await render(


### PR DESCRIPTION
## :pushpin: Summary

I have fixed an error in the `svgSize` method, where the `height` value was returned only if the `stretched` parameter was `true` (and so the `height` attribute was not assigned to the SVG element).

I have also bumped the `ember-flight-icon` addon version to `1.2.1` so if approved can be released straightaway.