### PR TITLE
simplify how we inject sprite for tests

### DIFF
--- a/ember-flight-icons/index.js
+++ b/ember-flight-icons/index.js
@@ -11,7 +11,7 @@ module.exports = {
     // otherwise the @percy/ember package ignores everything else and the SVG sprite is not added to the DOM
     // see thread: https://hashicorp.slack.com/archives/C11JCBJTW/p1633978558343000
     // see: https://github.com/percy/percy-ember/blob/master/addon-test-support/%40percy/ember/index.js#L33
-    if (type === 'body-footer' || type === 'ember-testing-sprite-embed') {
+    if (type === 'body-footer' || type === 'test-body-footer') {
       return flightIconSprite;
     }
   },

--- a/ember-flight-icons/tests/index.html
+++ b/ember-flight-icons/tests/index.html
@@ -24,10 +24,7 @@
     <div id="qunit"></div>
     <div id="qunit-fixture">
       <div id="ember-testing-container">
-        <div id="ember-testing">
-          <!-- this is used to inject the SVG sprite -->
-          {{content-for "ember-testing-sprite-embed"}}
-        </div>
+        <div id="ember-testing"></div>
       </div>
     </div>
 


### PR DESCRIPTION
## :pushpin: Summary

Use existing test-body-footer instead of creating a custom one