### PR TITLE
Streamline template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,9 +16,6 @@ This should be a short TL;DR that includes the purpose of the PR.
 
 <!-- Issues, RFC, etc. -->
 
-## :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
+***
 
-Examples: 
-- issue (ux, non-blocking): These buttons should be red, but let's handle this in a follow-up.
-- suggestion (non-blocking): Let's change this wording to make it easier to understand.
-- issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.
+:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,22 +16,9 @@ This should be a short TL;DR that includes the purpose of the PR.
 
 <!-- Issues, RFC, etc. -->
 
-
-## :building_construction: How to Build and Test the Change
-
-<!-- List steps to test your change on a local environment. -->
-
-
-## :+1: Definition of Done
-
-- [ ] New functionality works 
-- [ ] Accessibility addressed
-- [ ] Tests added
-- [ ] Docs updated
-
-### :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
+## :speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
 
 Examples: 
-- issue (ux,non-blocking): These buttons should be red, but let's handle this in a follow-up.
+- issue (ux, non-blocking): These buttons should be red, but let's handle this in a follow-up.
 - suggestion (non-blocking): Let's change this wording to make it easier to understand.
 - issue (blocking): We shouldn't introduce this kind of tech debt; let's pair and resolve the issue in a more sustainable way.


### PR DESCRIPTION
## :pushpin: Summary

The template seems long. Leaving the template as is proposed in the PR here in the description. 
- Suggesting to remove things that seem heavy-handed for this repo
- Wasn't sure why "conventional comments" was a h3 also

## :hammer_and_wrench: Detailed Description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

## :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

## :link: External Links

<!-- Issues, RFC, etc. -->

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.