### PR TITLE
Add dependabot for HashiCorp packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" 
+    directory: "ember-flight-icons/" 
+    versioning-strategy: increase
+    schedule:
+      interval: "daily"
+    allow: 
+      - dependency-name: "@hashicorp/*"
+


### PR DESCRIPTION
## :pushpin: Summary

Ref: We noticed forgot to bump flight-icons in ember-flight-icons here: https://github.com/hashicorp/flight/pull/356

Note: Can't really test this until it's merged. 

cc @didoo @MelSumner 

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
