### PR TITLE
Update documentation for React developers after feedback

### DIFF
--- a/website/app/templates/engineering.hbs
+++ b/website/app/templates/engineering.hbs
@@ -329,11 +329,16 @@
     <CodeBlock
       @language="js"
       @code="
-          // import the SVG file
-          const flightArrowRight = require('@hashicorp/flight-icons/svg/arrow-right-24.svg');
+          // import the SVG file (using 'require')
+          const flightArrowRight = require('@hashicorp/flight-icons/svg/arrow-right-24.svg?include');
+          // or import the SVG file (using 'import')
+          import flightArrowRight from '@hashicorp/flight-icons/svg/arrow-right-24.svg?include';
 
           // elsewhere in the file
           <InlineSvg src={flightArrowRight} />
+
+          // alternatively you can also use a similar approach
+          <InlineSvg src={require('@hashicorp/flight-icons/svg/arrow-right-24.svg?include')} />
         "
     />
     {{! prettier-ignore-end }}
@@ -355,26 +360,16 @@
     React/SVG</h3>
 
   <p>
-    Single icons can be imported and used directly as SVG files using the
-    <a
-      href="https://react-components.vercel.app/components/inlinesvg"
-      target="_blank"
-      rel="noopener noreferrer"
-    >&lt;InlineSvg&gt;</a>
-    provided by the
-    <a
-      href="https://github.com/hashicorp/react-components"
-      target="_blank"
-      rel="noopener noreferrer"
-    >@hashicorp/react-components</a>
-    library:
+    Single icons can be also imported and used directly as standalone React/SVG components:
     {{! template-lint-disable 'no-potential-path-strings' }}
     {{! prettier-ignore-start }}
     <CodeBlock
       @language="js"
       @code="
-          // import the React file (TypeScript)
-          const FlightArrowRight = require('@hashicorp/flight-icons/svg-react/arrow-right-24');
+          // import the React/TypeScript file (using 'require')
+          const FlightArrowRight = require('@hashicorp/flight-icons/svg-react/arrow-right-24?include');
+          // or import the React/TypeScript file (using 'import')
+          import { FlightArrowRight } from '@hashicorp/flight-icons/svg/arrow-right-24.svg?include';
 
           // elsewhere in the file
           <FlightArrowRight />

--- a/website/app/templates/engineering.hbs
+++ b/website/app/templates/engineering.hbs
@@ -330,12 +330,12 @@
       @language="js"
       @code="
           // import the SVG file (using 'require')
-          const flightArrowRight = require('@hashicorp/flight-icons/svg/arrow-right-24.svg?include');
+          const iconArrowRight = require('@hashicorp/flight-icons/svg/arrow-right-24.svg?include');
           // or import the SVG file (using 'import')
-          import flightArrowRight from '@hashicorp/flight-icons/svg/arrow-right-24.svg?include';
+          import iconArrowRight from '@hashicorp/flight-icons/svg/arrow-right-24.svg?include';
 
           // elsewhere in the file
-          <InlineSvg src={flightArrowRight} />
+          <InlineSvg src={iconArrowRight} />
 
           // alternatively you can also use a similar approach
           <InlineSvg src={require('@hashicorp/flight-icons/svg/arrow-right-24.svg?include')} />
@@ -367,12 +367,12 @@
       @language="js"
       @code="
           // import the React/TypeScript file (using 'require')
-          const FlightArrowRight = require('@hashicorp/flight-icons/svg-react/arrow-right-24?include');
+          const IconArrowRight24 = require('@hashicorp/flight-icons/svg-react/arrow-right-24?include');
           // or import the React/TypeScript file (using 'import')
-          import { FlightArrowRight } from '@hashicorp/flight-icons/svg/arrow-right-24.svg?include';
+          import { IconArrowRight24 } from '@hashicorp/flight-icons/svg/arrow-right-24.svg?include';
 
           // elsewhere in the file
-          <FlightArrowRight />
+          <IconArrowRight24 />
         "
     />
     {{! prettier-ignore-end }}

--- a/website/app/templates/engineering.hbs
+++ b/website/app/templates/engineering.hbs
@@ -367,9 +367,9 @@
       @language="js"
       @code="
           // import the React/TypeScript file (using 'require')
-          const IconArrowRight24 = require('@hashicorp/flight-icons/svg-react/arrow-right-24?include');
+          const { IconArrowRight24 } = require('@hashicorp/flight-icons/svg-react/arrow-right-24');
           // or import the React/TypeScript file (using 'import')
-          import { IconArrowRight24 } from '@hashicorp/flight-icons/svg/arrow-right-24.svg?include';
+          import { IconArrowRight24 } from '@hashicorp/flight-icons/svg-react/arrow-right-24';
 
           // elsewhere in the file
           <IconArrowRight24 />


### PR DESCRIPTION
In [this Slack comment](https://hashicorp.slack.com/archives/C7KTUHNUS/p1643048914096100?thread_ts=1643048240.095000&cid=C7KTUHNUS) @ashleemboyer raises a couple of valid points:

- The description under the “React/SVG” heading is the same as the one under “Inline SVG”
- We’ve been importing the icons like this in dev-portal, which is different from what I’m seeing in this page. I tried copy/pasting what’s in the docs and I’m getting some errors. Will have to investigate a little further but need to join to a meeting in a few `import { IconArrowRight16 } from '@hashicorp/flight-icons/svg-react/arrow-right-16'`

In this PR I have fixed both issues.

Preview: https://flight-git-update-docs-for-react-devs-hashicorp.vercel.app/engineering#use-react