### PR TITLE
bumped “ember-flight-icon” to 2.0.1

### DIFF
--- a/ember-flight-icons/package.json
+++ b/ember-flight-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/ember-flight-icons",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The Ember addon for the HashiCorp Flight SVG icon set",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
## :pushpin: Summary

In this PR I have:
- bumped the version of “ember-flight-icon” to `2.0.1` (the addon CSS was changed)