### PR TITLE
bump website dependency

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,7 @@
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@hashicorp/ember-flight-icons": "^2.0.0",
+    "@hashicorp/ember-flight-icons": "^2.0.1",
     "@hashicorp/flight-icons": "^2.1.0",
     "@percy/cli": "^1.0.0-beta.68",
     "@percy/ember": "^3.0.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1321,16 +1321,16 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
   integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
-"@hashicorp/ember-flight-icons@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-2.0.0.tgz#d4eb9082fe6579c54d481de4f1644f0c3188f37c"
-  integrity sha512-mCOyha0YnZjQcEomm2FKKL74BBvTrVJVjicxh+P5yu+Yo8hmiFOr0PbaoOuLrFOxsHsd33VW6Y5uskcZivR1tQ==
+"@hashicorp/ember-flight-icons@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-2.0.1.tgz#a627f5c0cd1e1a09c1c38620db9d10a55acd4701"
+  integrity sha512-fQTJT3GpzHv/zn6QpV6q3mPccEdYUeAcf4rRntIa8FtyodxxNCEktZGU5Nxr3Q+uqP16PpJkyWAn3J/MNRmnIg==
   dependencies:
-    "@hashicorp/flight-icons" "^2.0.0"
+    "@hashicorp/flight-icons" "^2.1.0"
     ember-cli-babel "^7.26.6"
     ember-cli-htmlbars "^5.7.1"
 
-"@hashicorp/flight-icons@^2.0.0", "@hashicorp/flight-icons@^2.1.0":
+"@hashicorp/flight-icons@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-2.1.0.tgz#bda6c6942af0432d3342b1b1a2ff7f8da4c10f8a"
   integrity sha512-4HWwty+LNhMD7O30sBinn7OQo2KTSUEk1qm65hqFitfp2m8sEl8F+7gY4NcTJV9Y1eEe3C7bED5OOnsPVc60ww==


### PR DESCRIPTION
## :pushpin: Summary

In this PR I have bumped the `ember-flight-icon` dependency to `2.0.1`